### PR TITLE
All integration tests IDisposable and dispose of sut.

### DIFF
--- a/src/QuartzNET-DynamoDB.Tests/Integration/JobStore/CalendarAddTests.cs
+++ b/src/QuartzNET-DynamoDB.Tests/Integration/JobStore/CalendarAddTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Quartz.Impl.Calendar;
 using Quartz.Simpl;
 using Quartz.Spi;
@@ -9,9 +9,9 @@ namespace Quartz.DynamoDB.Tests.Integration.JobStore
     /// <summary>
     /// Contains tests related to the addition of calendars.
     /// </summary>
-    public class CalendarAddTests
+    public class CalendarAddTests : IDisposable
     {
-        IJobStore _sut;
+        private readonly DynamoDB.JobStore _sut;
 
         public CalendarAddTests()
         {
@@ -35,6 +35,11 @@ namespace Quartz.DynamoDB.Tests.Integration.JobStore
             Assert.NotNull(storedCalendar);
             Assert.Equal(cal.Description, storedCalendar.Description);
             Assert.Equal(cal.GetType(), storedCalendar.GetType());
+        }
+
+        public void Dispose()
+        {
+            _sut.Dispose();
         }
     }
 }

--- a/src/QuartzNET-DynamoDB.Tests/Integration/JobStore/CalendarGetTests.cs
+++ b/src/QuartzNET-DynamoDB.Tests/Integration/JobStore/CalendarGetTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using Quartz.Impl.Calendar;
 using Quartz.Simpl;
@@ -10,9 +10,9 @@ namespace Quartz.DynamoDB.Tests.Integration.JobStore
     /// <summary>
     /// Contains tests related to the loading of calendars.
     /// </summary>
-    public class CalendarGetTests
+    public class CalendarGetTests : IDisposable
     {
-        IJobStore _sut;
+        private readonly DynamoDB.JobStore _sut;
 
         public CalendarGetTests()
         {
@@ -43,7 +43,6 @@ namespace Quartz.DynamoDB.Tests.Integration.JobStore
 
             Assert.Equal(calendarCount + 1, newCount);
         }
-
 
         /// <summary>
         /// Tests that after a calendar is added, the calendar exists method returns true.
@@ -77,6 +76,11 @@ namespace Quartz.DynamoDB.Tests.Integration.JobStore
             var result = _sut.GetCalendarNames();
 
             Assert.True(result.Contains(calName));
+        }
+
+        public void Dispose()
+        {
+            _sut.Dispose();
         }
     }
 }

--- a/src/QuartzNET-DynamoDB.Tests/Integration/JobStore/JobAddTests.cs
+++ b/src/QuartzNET-DynamoDB.Tests/Integration/JobStore/JobAddTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Quartz.DynamoDB.Tests.Integration;
 using Quartz.Impl;
@@ -12,9 +12,9 @@ namespace Quartz.DynamoDB.Tests.Integration.JobStore
 	/// <summary>
 	/// Contains tests related to the Addition of Jobs and Job Groups.
 	/// </summary>
-	public class JobAddTests
+    public class JobAddTests : IDisposable
 	{
-		IJobStore _sut;
+        private readonly DynamoDB.JobStore _sut;
 
 		public JobAddTests ()
 		{
@@ -90,6 +90,11 @@ namespace Quartz.DynamoDB.Tests.Integration.JobStore
 
 			Assert.Throws<ObjectAlreadyExistsException> (() => _sut.StoreJob (detail, false));
 		}
+
+        public void Dispose()
+        {
+            _sut.Dispose();
+        }
 	}
 }
 

--- a/src/QuartzNET-DynamoDB.Tests/Integration/JobStore/JobGetTests.cs
+++ b/src/QuartzNET-DynamoDB.Tests/Integration/JobStore/JobGetTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using Quartz.DynamoDB.Tests.Integration;
 using Quartz.Impl;
@@ -11,9 +11,9 @@ namespace Quartz.DynamoDB.Tests.Integration.JobStore
 	/// <summary>
 	/// Contains tests related to retrieving Jobs and Job Groups.
 	/// </summary>
-	public class JobGetTests
+    public class JobGetTests : IDisposable
 	{
-		IJobStore _sut;
+        private readonly DynamoDB.JobStore _sut;
 
 		public JobGetTests ()
 		{
@@ -44,6 +44,11 @@ namespace Quartz.DynamoDB.Tests.Integration.JobStore
 			Assert.Equal(jobCount + 1, newCount);
 
 		}
+
+        public void Dispose()
+        {
+            _sut.Dispose();
+        }
 	}
 }
 

--- a/src/QuartzNET-DynamoDB.Tests/Integration/JobStore/JobPauseTests.cs
+++ b/src/QuartzNET-DynamoDB.Tests/Integration/JobStore/JobPauseTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Quartz.Simpl;
 using Quartz.Spi;
 using Xunit;
@@ -11,9 +11,9 @@ namespace Quartz.DynamoDB.Tests.Integration.JobStore
     /// <summary>
     /// Contains tests related to the Pausing of Jobs and Job Groups.
     /// </summary>
-    public class JobPauseTests
+    public class JobPauseTests : IDisposable
     {
-        IJobStore _sut;
+        private readonly DynamoDB.JobStore _sut;
 
         public JobPauseTests()
         {
@@ -85,6 +85,11 @@ namespace Quartz.DynamoDB.Tests.Integration.JobStore
 
             paused = _sut.IsJobGroupPaused(jobGroup);
             Assert.Equal(true, paused);
+        }
+
+        public void Dispose()
+        {
+            _sut.Dispose();
         }
     }
 }

--- a/src/QuartzNET-DynamoDB.Tests/Integration/JobStore/JobRemoveTests.cs
+++ b/src/QuartzNET-DynamoDB.Tests/Integration/JobStore/JobRemoveTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Quartz.Impl;
 using Quartz.Job;
@@ -11,9 +11,9 @@ namespace Quartz.DynamoDB.Tests.Integration.JobStore
 	/// <summary>
 	/// Contains tests related to the Removal of Jobs and Job Groups.
 	/// </summary>
-	public class JobRemoveTests
+    public class JobRemoveTests : IDisposable
 	{
-		IJobStore _sut;
+        private readonly DynamoDB.JobStore _sut;
 
 		public JobRemoveTests ()
 		{
@@ -74,6 +74,11 @@ namespace Quartz.DynamoDB.Tests.Integration.JobStore
 			// Should return false as not all jobs were removed.
             Assert.False(result);
 		}
+
+        public void Dispose()
+        {
+            _sut.Dispose();
+        }
 	}
 }
 

--- a/src/QuartzNET-DynamoDB.Tests/Integration/JobStore/JobResumeTests.cs
+++ b/src/QuartzNET-DynamoDB.Tests/Integration/JobStore/JobResumeTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using Quartz.Simpl;
 using Quartz.Spi;
@@ -9,9 +9,9 @@ namespace Quartz.DynamoDB.Tests.Integration.JobStore
     /// <summary>
     /// Contains tests related to the Resumption of Jobs and Job Groups.
     /// </summary>
-    public class JobResumeTests
+    public class JobResumeTests : IDisposable
     {
-        private readonly IJobStore _sut;
+        private readonly DynamoDB.JobStore _sut;
 
         public JobResumeTests()
         {
@@ -106,6 +106,11 @@ namespace Quartz.DynamoDB.Tests.Integration.JobStore
             // Check the job group is resumed
             paused = _sut.IsJobGroupPaused(jobGroup);
             Assert.Equal(false, paused);
+        }
+
+        public void Dispose()
+        {
+            _sut.Dispose();
         }
     }
 }

--- a/src/QuartzNET-DynamoDB.Tests/Integration/JobStore/JobsAndTriggersAddTests.cs
+++ b/src/QuartzNET-DynamoDB.Tests/Integration/JobStore/JobsAndTriggersAddTests.cs
@@ -1,8 +1,7 @@
-﻿using System.Collections.Generic;
-using Quartz.DynamoDB;
+using System;
+using System.Collections.Generic;
 using Quartz.Job;
 using Quartz.Simpl;
-using Quartz.Spi;
 using Xunit;
 
 namespace Quartz.DynamoDB.Tests.Integration.JobStore
@@ -10,9 +9,9 @@ namespace Quartz.DynamoDB.Tests.Integration.JobStore
     /// <summary>
     /// Contains tests related to the addition of Jobs and Triggers.
     /// </summary>
-    public class JobsAndTriggersAddTests
+    public class JobsAndTriggersAddTests : IDisposable
     {
-        private readonly IJobStore _sut;
+        private readonly DynamoDB.JobStore _sut;
 
         public JobsAndTriggersAddTests()
         {
@@ -91,6 +90,11 @@ namespace Quartz.DynamoDB.Tests.Integration.JobStore
 
             var storedJob = _sut.RetrieveJob(job.Key);
             Assert.Equal(initialJobDescription, storedJob.Description);
+        }
+
+        public void Dispose()
+        {
+            _sut.Dispose();
         }
     }
 }

--- a/src/QuartzNET-DynamoDB.Tests/Integration/JobStore/SchedulerIntegrationTests.cs
+++ b/src/QuartzNET-DynamoDB.Tests/Integration/JobStore/SchedulerIntegrationTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Xunit;
 using Quartz.DynamoDB.DataModel.Storage;
 using Quartz.DynamoDB.DataModel;
@@ -7,10 +7,14 @@ using Quartz.Simpl;
 
 namespace Quartz.DynamoDB.Tests.Integration.JobStore
 {
-	public class SchedulerIntegrationTests
+    public class SchedulerIntegrationTests : IDisposable
 	{
+        private readonly DynamoDB.JobStore _sut;
+
 		public SchedulerIntegrationTests ()
 		{
+            _sut = new Quartz.DynamoDB.JobStore();
+
 		}
 			
 		[Fact]
@@ -21,35 +25,39 @@ namespace Quartz.DynamoDB.Tests.Integration.JobStore
 		/// </summary>
 		public void SingleSchedulerCreated()
 		{
-			var sut = new Quartz.DynamoDB.JobStore ();
 			var signaler = new Quartz.DynamoDB.Tests.Integration.RamJobStoreTests.SampleSignaler();
 			var loadHelper = new SimpleTypeLoadHelper();
 
-			sut.Initialize(loadHelper, signaler);
+			_sut.Initialize(loadHelper, signaler);
 			var client = DynamoDbClientFactory.Create();
 			var schedulerRepository = new Repository<DynamoScheduler> (client);
 
 			int intialSchedulerCount = schedulerRepository.Scan (null, null, null).Count();
 
-			sut.SchedulerStarted ();
+			_sut.SchedulerStarted ();
 
 			int schedulerStartedCount = schedulerRepository.Scan (null, null, null).Count();
 
 			Assert.Equal (intialSchedulerCount + 1, schedulerStartedCount);
 
-			sut.SchedulerPaused ();
+			_sut.SchedulerPaused ();
 
 			int schedulerPausedCount = schedulerRepository.Scan (null, null, null).Count();
 
 			Assert.Equal (intialSchedulerCount + 1, schedulerPausedCount);
 
-			sut.AcquireNextTriggers (new DateTimeOffset(DateTime.Now), 1, TimeSpan.FromMinutes(5));
+			_sut.AcquireNextTriggers (new DateTimeOffset(DateTime.Now), 1, TimeSpan.FromMinutes(5));
 
 			int triggersAcquiredCount = schedulerRepository.Scan (null, null, null).Count();
 
 			Assert.Equal (intialSchedulerCount + 1, triggersAcquiredCount);
 
 		}
+
+        public void Dispose()
+        {
+            _sut.Dispose();
+        }
 	}
 }
 

--- a/src/QuartzNET-DynamoDB.Tests/Integration/JobStore/TriggerAddTests.cs
+++ b/src/QuartzNET-DynamoDB.Tests/Integration/JobStore/TriggerAddTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Quartz.DynamoDB.Tests.Integration;
 using Quartz.Simpl;
 using Quartz.Spi;
@@ -6,9 +6,9 @@ using Xunit;
 
 namespace Quartz.DynamoDB.Tests.Integration.JobStore
 {
-    public class TriggerAddTests
+    public class TriggerAddTests : IDisposable
     {
-        IJobStore _sut;
+        private readonly DynamoDB.JobStore _sut;
 
         public TriggerAddTests()
         {
@@ -74,6 +74,10 @@ namespace Quartz.DynamoDB.Tests.Integration.JobStore
             Assert.Equal(TriggerState.Normal, newTriggerState);
         }
 
+        public void Dispose()
+        {
+            _sut.Dispose();
+        }
     }
 }
 

--- a/src/QuartzNET-DynamoDB.Tests/Integration/JobStore/TriggerGetTests.cs
+++ b/src/QuartzNET-DynamoDB.Tests/Integration/JobStore/TriggerGetTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using Quartz.DynamoDB.Tests.Integration;
 using Quartz.Simpl;
@@ -7,9 +7,9 @@ using Xunit;
 
 namespace Quartz.DynamoDB.Tests.Integration.JobStore
 {
-	public class GetTriggerTests
+    public class GetTriggerTests : IDisposable
 	{
-		IJobStore _sut;
+        private readonly DynamoDB.JobStore _sut;
 
 		public GetTriggerTests ()
 		{
@@ -36,6 +36,11 @@ namespace Quartz.DynamoDB.Tests.Integration.JobStore
 			int newTriggerCount = _sut.GetNumberOfTriggers ();
 			Assert.Equal (triggerCount + 1, newTriggerCount);
 		}
+
+        public void Dispose()
+        {
+            _sut.Dispose();
+        }
 	}
 }
 

--- a/src/QuartzNET-DynamoDB.Tests/Integration/JobStore/TriggerGroupGetTests.cs
+++ b/src/QuartzNET-DynamoDB.Tests/Integration/JobStore/TriggerGroupGetTests.cs
@@ -1,13 +1,13 @@
-﻿using System;
+using System;
 using Quartz.Simpl;
 using Quartz.Spi;
 using Xunit;
 
 namespace Quartz.DynamoDB.Tests.Integration.JobStore
 {
-    public class TriggerGroupGetTests
+    public class TriggerGroupGetTests : IDisposable
     {
-        IJobStore _sut;
+        private readonly DynamoDB.JobStore _sut;
 
         public TriggerGroupGetTests()
         {
@@ -32,6 +32,11 @@ namespace Quartz.DynamoDB.Tests.Integration.JobStore
             var result = _sut.GetPausedTriggerGroups();
 
             Assert.True(result.Contains(triggerGroup));
+        }
+
+        public void Dispose()
+        {
+            _sut.Dispose();
         }
     }
 }

--- a/src/QuartzNET-DynamoDB.Tests/Integration/JobStore/TriggerPauseTests.cs
+++ b/src/QuartzNET-DynamoDB.Tests/Integration/JobStore/TriggerPauseTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Xunit;
 using Quartz.Simpl;
 using Quartz.Spi;
@@ -15,9 +15,9 @@ namespace Quartz.DynamoDB.Tests.Integration.JobStore
     /// <summary>
     /// Contains tests related to the Pausing of Triggers and Trigger Groups.
     /// </summary>
-    public class TriggerPauseTests
+    public class TriggerPauseTests : IDisposable
     {
-        IJobStore _sut;
+        private readonly DynamoDB.JobStore _sut;
 
         public TriggerPauseTests()
         {
@@ -181,6 +181,11 @@ namespace Quartz.DynamoDB.Tests.Integration.JobStore
 
             paused = _sut.IsTriggerGroupPaused(triggerGroup);
             Assert.Equal(true, paused);
+        }
+
+        public void Dispose()
+        {
+            _sut.Dispose();
         }
     }
 }

--- a/src/QuartzNET-DynamoDB.Tests/Integration/JobStore/TriggerRemoveTests.cs
+++ b/src/QuartzNET-DynamoDB.Tests/Integration/JobStore/TriggerRemoveTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Quartz.DynamoDB.Tests.Integration;
 using Quartz.Impl;
@@ -9,9 +9,9 @@ using Xunit;
 
 namespace Quartz.DynamoDB.Tests.Integration.JobStore
 {
-    public class TriggerRemoveTests
+    public class TriggerRemoveTests : IDisposable
     {
-        IJobStore _sut;
+        private readonly DynamoDB.JobStore _sut;
 
         public TriggerRemoveTests()
         {
@@ -80,6 +80,11 @@ namespace Quartz.DynamoDB.Tests.Integration.JobStore
 
             var result = _sut.RemoveTriggers(new List<TriggerKey>() { tr.Key, inMemoryTr.Key });
             Assert.False(result);
+        }
+
+        public void Dispose()
+        {
+            _sut.Dispose();
         }
     }
 }

--- a/src/QuartzNET-DynamoDB.Tests/Integration/JobStore/TriggerResumeTests.cs
+++ b/src/QuartzNET-DynamoDB.Tests/Integration/JobStore/TriggerResumeTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Xunit;
 using Quartz.Simpl;
 using Quartz.Spi;
@@ -11,9 +11,9 @@ namespace Quartz.DynamoDB.Tests.Integration.JobStore
     /// <summary>
     /// Contains tests related to Resuming Triggers and Trigger Groups.
     /// </summary>
-    public class TriggerResumeTests
+    public class TriggerResumeTests : IDisposable
     {
-        IJobStore _sut;
+        private readonly DynamoDB.JobStore _sut;
 
         public TriggerResumeTests()
         {
@@ -89,6 +89,11 @@ namespace Quartz.DynamoDB.Tests.Integration.JobStore
 
             triggerState2 = _sut.GetTriggerState(tr2.Key);
             Assert.Equal("Normal", triggerState2.ToString());
+        }
+
+        public void Dispose()
+        {
+            _sut.Dispose();
         }
     }
 }

--- a/src/QuartzNET-DynamoDB.Tests/Integration/JobStore/TriggersFiredTests.cs
+++ b/src/QuartzNET-DynamoDB.Tests/Integration/JobStore/TriggersFiredTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Xunit;
 using Quartz.Impl;
 using Quartz.Job;
@@ -12,9 +12,9 @@ namespace Quartz.DynamoDB.Tests.Integration.JobStore
 	/// <summary>
 	/// Contains tests for the JobStore when triggers are fired.
 	/// </summary>
-	public class JobStoreTriggersFiredTests
+    public class JobStoreTriggersFiredTests : IDisposable
 	{
-		IJobStore _sut;
+        private readonly DynamoDB.JobStore _sut;
 
 		public JobStoreTriggersFiredTests ()
 		{
@@ -57,6 +57,11 @@ namespace Quartz.DynamoDB.Tests.Integration.JobStore
 			Assert.Equal(jobName, result [0].TriggerFiredBundle.JobDetail.Key.Name);
 			Assert.Equal(jobGroup, result [0].TriggerFiredBundle.JobDetail.Key.Group);
 		}
+
+        public void Dispose()
+        {
+            _sut.Dispose();
+        }
 	}
 }
 


### PR DESCRIPTION
A crazy theory I had related to https://github.com/lukeryannetnz/quartznet-dynamodb/pull/19

Possibly not the cause of the hanging integration tests, but a nice tidy up anyway. 
Xunit calls dispose, however perhaps we should look to move away from any members in tests at all as per... http://jamesnewkirk.typepad.com/posts/2007/09/why-you-should-.html