### PR TITLE
Storing datetimes as utc epoch

### DIFF
--- a/src/QuartzNET-DynamoDB.Tests/Unit/CalendarSerialisationTests.cs
+++ b/src/QuartzNET-DynamoDB.Tests/Unit/CalendarSerialisationTests.cs
@@ -110,18 +110,15 @@ namespace Quartz.DynamoDB.Tests.Unit
         [Trait("Category", "Unit")]
         public void HolidayCalendarExcludedDays()
         {
-            var importantDate = new DateTime(2015, 04, 02);
-
-            HolidayCalendar cal = new HolidayCalendar();
-            cal.AddExcludedDate(DateTime.Today);
-            cal.AddExcludedDate(importantDate);
+            var importantDate = new DateTime(2015, 04, 02, 5, 5, 5, DateTimeKind.Utc);
+            var cal = new HolidayCalendar();
+            cal.AddExcludedDate(importantDate.Date);
 
             var sut = new DynamoCalendar("test", cal);
             var serialised = sut.ToDynamo();
             var deserialised = new DynamoCalendar(serialised);
 
-            Assert.True(((HolidayCalendar)deserialised.Calendar).ExcludedDates.Contains(DateTime.Today));
-            Assert.True(((HolidayCalendar)deserialised.Calendar).ExcludedDates.Contains(importantDate));
+            Assert.True(((HolidayCalendar)deserialised.Calendar).ExcludedDates.Contains(importantDate.Date));
         }
 
         /// <summary>

--- a/src/QuartzNET-DynamoDB.Tests/Unit/CalendarSerialisationTests.cs
+++ b/src/QuartzNET-DynamoDB.Tests/Unit/CalendarSerialisationTests.cs
@@ -113,12 +113,14 @@ namespace Quartz.DynamoDB.Tests.Unit
             var importantDate = new DateTime(2015, 04, 02, 5, 5, 5, DateTimeKind.Utc);
             var cal = new HolidayCalendar();
             cal.AddExcludedDate(importantDate.Date);
+            cal.AddExcludedDate(DateTime.UtcNow.Date);
 
             var sut = new DynamoCalendar("test", cal);
             var serialised = sut.ToDynamo();
             var deserialised = new DynamoCalendar(serialised);
 
             Assert.True(((HolidayCalendar)deserialised.Calendar).ExcludedDates.Contains(importantDate.Date));
+            Assert.True(((HolidayCalendar)deserialised.Calendar).ExcludedDates.Contains(DateTime.UtcNow.Date));
         }
 
         /// <summary>

--- a/src/QuartzNET-DynamoDB/DataModel/DateTimeConverter.cs
+++ b/src/QuartzNET-DynamoDB/DataModel/DateTimeConverter.cs
@@ -1,0 +1,30 @@
+﻿using System;
+
+namespace Quartz.DynamoDB.DataModel
+{
+    /// <summary>
+    /// Converts .NET DateTime objects to integer UTC unix-EPOCH time format for storage.
+    /// </summary>
+    public class DateTimeConverter
+    {
+        /// <summary>
+        /// Returns a dynamodb entry (int) with the datetime relative to unix epoch time.
+        /// </summary>
+        /// <param name="datetime"></param>
+        /// <returns></returns>
+        public int ToEntry(DateTime datetime)
+        {
+            return datetime.ToUniversalTime().ToUnixEpochTime();
+        }
+
+        /// <summary>
+        /// Returns the UTC DateTime that the epoch dynamo record represents.
+        /// </summary>
+        /// <param name="secondsSinceUtcEpoch"></param>
+        /// <returns></returns>
+        public DateTime FromEntry(int secondsSinceUtcEpoch)
+        {
+            return UnixEpochDateTimeExtensions.UtcEpochTime.AddSeconds(secondsSinceUtcEpoch);
+        }
+    }
+}

--- a/src/QuartzNET-DynamoDB/DataModel/DynamoTrigger.cs
+++ b/src/QuartzNET-DynamoDB/DataModel/DynamoTrigger.cs
@@ -12,10 +12,10 @@ namespace Quartz.DynamoDB.DataModel
     /// <summary>
     /// A wrapper class for a Quartz Trigger instance that can be serialized and stored in Amazon DynamoDB.
     /// </summary>
-	public class DynamoTrigger : IInitialisableFromDynamoRecord,IConvertibleToDynamoRecord, IDynamoTableType
+    public class DynamoTrigger : IInitialisableFromDynamoRecord,IConvertibleToDynamoRecord, IDynamoTableType
     {
-		private readonly JobDataMapConverter jobDataMapConverter = new JobDataMapConverter();
-		private readonly DateTimeOffsetConverter dateTimeOffsetConverter = new DateTimeOffsetConverter();
+        private readonly JobDataMapConverter _jobDataMapConverter = new JobDataMapConverter();
+        private readonly DateTimeOffsetConverter _dateTimeOffsetConverter = new DateTimeOffsetConverter();
 
         public DynamoTrigger()
         {
@@ -34,127 +34,127 @@ namespace Quartz.DynamoDB.DataModel
 
         public DynamoTrigger(Dictionary<string, AttributeValue> item)
         {
-			InitialiseFromDynamoRecord(item);
+            InitialiseFromDynamoRecord(item);
         }
-			
-		public void InitialiseFromDynamoRecord (Dictionary<string, AttributeValue> record)
-		{
-			string type = record.ContainsKey ("Type") ? record ["Type"].S : string.Empty;
-			Debug.WriteLine("Initialising trigger of Type: {0}", type);
+            
+        public void InitialiseFromDynamoRecord (Dictionary<string, AttributeValue> record)
+        {
+            string type = record.ContainsKey ("Type") ? record ["Type"].S : string.Empty;
+            Debug.WriteLine("Initialising trigger of Type: {0}", type);
 
-			switch (type)
-			{
-			case "CalendarIntervalTriggerImpl":
-				{
-					var calendarTrigger = new CalendarIntervalTriggerImpl();
-					Trigger = calendarTrigger;
+            switch (type)
+            {
+            case "CalendarIntervalTriggerImpl":
+                {
+                    var calendarTrigger = new CalendarIntervalTriggerImpl();
+                    Trigger = calendarTrigger;
 
-					calendarTrigger.PreserveHourOfDayAcrossDaylightSavings = record["PreserveHourOfDayAcrossDaylightSavings"].BOOL;
-					calendarTrigger.RepeatInterval = int.Parse(record["RepeatInterval"].N);
-					calendarTrigger.RepeatIntervalUnit = (IntervalUnit)int.Parse(record["RepeatIntervalUnit"].N);
-					calendarTrigger.TimesTriggered = int.Parse(record["TimesTriggered"].N);
-					calendarTrigger.TimeZone = TimeZoneInfo.FromSerializedString(record["TimeZone"].S);
-					break;
-				}
-			case "CronTriggerImpl":
-				{
-					Trigger = new CronTriggerImpl();
-					//todo: support CronTrigger
-					break;
-				}
+                    calendarTrigger.PreserveHourOfDayAcrossDaylightSavings = record["PreserveHourOfDayAcrossDaylightSavings"].BOOL;
+                    calendarTrigger.RepeatInterval = int.Parse(record["RepeatInterval"].N);
+                    calendarTrigger.RepeatIntervalUnit = (IntervalUnit)int.Parse(record["RepeatIntervalUnit"].N);
+                    calendarTrigger.TimesTriggered = int.Parse(record["TimesTriggered"].N);
+                    calendarTrigger.TimeZone = TimeZoneInfo.FromSerializedString(record["TimeZone"].S);
+                    break;
+                }
+            case "CronTriggerImpl":
+                {
+                    Trigger = new CronTriggerImpl();
+                    //todo: support CronTrigger
+                    break;
+                }
 
-			case "DailyTimeIntervalTriggerImpl":
-				{
-					var dailyTrigger = new DailyTimeIntervalTriggerImpl();
-					Trigger = dailyTrigger;
+            case "DailyTimeIntervalTriggerImpl":
+                {
+                    var dailyTrigger = new DailyTimeIntervalTriggerImpl();
+                    Trigger = dailyTrigger;
 
-					var daysOfWeek = record["DaysOfWeek"].L
-						.Select(dow => (DayOfWeek)Enum.Parse(typeof(DayOfWeek), dow.S));
+                    var daysOfWeek = record["DaysOfWeek"].L
+                        .Select(dow => (DayOfWeek)Enum.Parse(typeof(DayOfWeek), dow.S));
 
-					dailyTrigger.DaysOfWeek = new Quartz.Collection.HashSet<DayOfWeek>(daysOfWeek);
+                    dailyTrigger.DaysOfWeek = new Quartz.Collection.HashSet<DayOfWeek>(daysOfWeek);
 
-					int endTimeOfDayHour = int.Parse(record["EndTimeOfDay_Hour"].N);
-					int endTimeOfDayMin = int.Parse(record["EndTimeOfDay_Minute"].N);
-					int endTimeOfDaySec = int.Parse(record["EndTimeOfDay_Second"].N);
-					dailyTrigger.EndTimeOfDay = new TimeOfDay(endTimeOfDayHour, endTimeOfDayMin, endTimeOfDaySec);
-					dailyTrigger.RepeatCount = int.Parse(record["RepeatCount"].N);
-					dailyTrigger.RepeatInterval = int.Parse(record["RepeatInterval"].N);
-					dailyTrigger.RepeatIntervalUnit = (IntervalUnit)int.Parse(record["RepeatIntervalUnit"].N);
-					int startTimeOfDayHour = int.Parse(record["StartTimeOfDay_Hour"].N);
-					int startTimeOfDayMin = int.Parse(record["StartTimeOfDay_Minute"].N);
-					int startTimeOfDaySec = int.Parse(record["StartTimeOfDay_Second"].N);
-					dailyTrigger.StartTimeOfDay = new TimeOfDay(startTimeOfDayHour, startTimeOfDayMin, startTimeOfDaySec);
-					dailyTrigger.TimesTriggered = int.Parse(record["TimesTriggered"].N);
-					dailyTrigger.TimeZone = TimeZoneInfo.FromSerializedString(record["TimeZone"].S);
-					break;
-				}
+                    int endTimeOfDayHour = int.Parse(record["EndTimeOfDay_Hour"].N);
+                    int endTimeOfDayMin = int.Parse(record["EndTimeOfDay_Minute"].N);
+                    int endTimeOfDaySec = int.Parse(record["EndTimeOfDay_Second"].N);
+                    dailyTrigger.EndTimeOfDay = new TimeOfDay(endTimeOfDayHour, endTimeOfDayMin, endTimeOfDaySec);
+                    dailyTrigger.RepeatCount = int.Parse(record["RepeatCount"].N);
+                    dailyTrigger.RepeatInterval = int.Parse(record["RepeatInterval"].N);
+                    dailyTrigger.RepeatIntervalUnit = (IntervalUnit)int.Parse(record["RepeatIntervalUnit"].N);
+                    int startTimeOfDayHour = int.Parse(record["StartTimeOfDay_Hour"].N);
+                    int startTimeOfDayMin = int.Parse(record["StartTimeOfDay_Minute"].N);
+                    int startTimeOfDaySec = int.Parse(record["StartTimeOfDay_Second"].N);
+                    dailyTrigger.StartTimeOfDay = new TimeOfDay(startTimeOfDayHour, startTimeOfDayMin, startTimeOfDaySec);
+                    dailyTrigger.TimesTriggered = int.Parse(record["TimesTriggered"].N);
+                    dailyTrigger.TimeZone = TimeZoneInfo.FromSerializedString(record["TimeZone"].S);
+                    break;
+                }
 
-			case "SimpleTriggerImpl":
-				{
-					var simpleTrigger = new SimpleTriggerImpl();
-					Trigger = simpleTrigger;
+            case "SimpleTriggerImpl":
+                {
+                    var simpleTrigger = new SimpleTriggerImpl();
+                    Trigger = simpleTrigger;
 
-					simpleTrigger.RepeatCount = int.Parse(record["RepeatCount"].N);
-					simpleTrigger.RepeatInterval = new TimeSpan(long.Parse(record["RepeatInterval"].N));
-					simpleTrigger.TimesTriggered = int.Parse(record["TimesTriggered"].N);
-					break;
-				}
-			default:
-				{
-					Trigger = new SimpleTriggerImpl();
-					break;
-				}
-			}
+                    simpleTrigger.RepeatCount = int.Parse(record["RepeatCount"].N);
+                    simpleTrigger.RepeatInterval = new TimeSpan(long.Parse(record["RepeatInterval"].N));
+                    simpleTrigger.TimesTriggered = int.Parse(record["TimesTriggered"].N);
+                    break;
+                }
+            default:
+                {
+                    Trigger = new SimpleTriggerImpl();
+                    break;
+                }
+            }
 
-			State = record ["State"].S;
-			SchedulerInstanceId = record ["SchedulerInstanceId"].S;
-			Trigger.Name = record["Name"].S;
-			Trigger.Group = record["Group"].S;
-			Trigger.JobName = record["JobName"].S;
-			Trigger.JobGroup = record["JobGroup"].S;
-			Trigger.Description = record["Description"].S;
-			Trigger.CalendarName = record["CalendarName"].S;
-			Trigger.JobDataMap = (JobDataMap)jobDataMapConverter.FromEntry(record["JobDataMap"]);
-			Trigger.MisfireInstruction = int.Parse(record["MisfireInstruction"].N);
-			Trigger.FireInstanceId = record["FireInstanceId"].S;
+            State = record ["State"].S;
+            SchedulerInstanceId = record ["SchedulerInstanceId"].S;
+            Trigger.Name = record["Name"].S;
+            Trigger.Group = record["Group"].S;
+            Trigger.JobName = record["JobName"].S;
+            Trigger.JobGroup = record["JobGroup"].S;
+            Trigger.Description = record["Description"].S;
+            Trigger.CalendarName = record["CalendarName"].S;
+            Trigger.JobDataMap = (JobDataMap)_jobDataMapConverter.FromEntry(record["JobDataMap"]);
+            Trigger.MisfireInstruction = int.Parse(record["MisfireInstruction"].N);
+            Trigger.FireInstanceId = record["FireInstanceId"].S;
 
-			Trigger.StartTimeUtc = DateTimeOffset.Parse(record["StartTimeUtc"].S);
+            Trigger.StartTimeUtc = _dateTimeOffsetConverter.FromEntry(int.Parse(record["StartTimeUtcEpoch"].N));
 
-			if(record.ContainsKey("EndTimeUtc"))
-			{
-				Trigger.EndTimeUtc = DateTimeOffset.Parse(record["EndTimeUtc"].S);
-			}
+            if (record.ContainsKey("EndTimeUtcEpoch"))
+            {
+                Trigger.EndTimeUtc = _dateTimeOffsetConverter.FromEntry(int.Parse(record["EndTimeUtcEpoch"].N));
+            }
 
-			if(record.ContainsKey("NextFireTimeUtcEpoch"))
-			{
-				Trigger.SetNextFireTimeUtc(dateTimeOffsetConverter.FromEntry(int.Parse(record["NextFireTimeUtcEpoch"].N)));
-				Debug.WriteLine("Setting Trigger NextFireTimeUTC {0}", Trigger.GetNextFireTimeUtc().Value);
-			}
+            if(record.ContainsKey("NextFireTimeUtcEpoch"))
+            {
+                Trigger.SetNextFireTimeUtc(_dateTimeOffsetConverter.FromEntry(int.Parse(record["NextFireTimeUtcEpoch"].N)));
+                Debug.WriteLine("Setting Trigger NextFireTimeUTC {0}", Trigger.GetNextFireTimeUtc().Value);
+            }
 
-			if(record.ContainsKey("PreviousFireTimeUtcEpoch"))
-			{
-				Trigger.SetPreviousFireTimeUtc(dateTimeOffsetConverter.FromEntry(int.Parse(record["PreviousFireTimeUtcEpoch"].N)));
-			}
+            if(record.ContainsKey("PreviousFireTimeUtcEpoch"))
+            {
+                Trigger.SetPreviousFireTimeUtc(_dateTimeOffsetConverter.FromEntry(int.Parse(record["PreviousFireTimeUtcEpoch"].N)));
+            }
 
-			Trigger.Priority = int.Parse(record["Priority"].N);
-		}
+            Trigger.Priority = int.Parse(record["Priority"].N);
+        }
 
-		public string DynamoTableName  
-		{
-			get 
-			{
-				return DynamoConfiguration.TriggerTableName;
-			}
-		}
+        public string DynamoTableName  
+        {
+            get 
+            {
+                return DynamoConfiguration.TriggerTableName;
+            }
+        }
 
-		public Dictionary<string, AttributeValue> Key 
-		{ 
-			get 
-			{
-				return Trigger.Key.ToDictionary ();
-			}
-		}
-			
+        public Dictionary<string, AttributeValue> Key 
+        { 
+            get 
+            {
+                return Trigger.Key.ToDictionary ();
+            }
+        }
+            
         public AbstractTrigger Trigger { get; set; }
 
         /// <summary>
@@ -214,8 +214,8 @@ namespace Quartz.DynamoDB.DataModel
         {
             Dictionary<string, AttributeValue> record = new Dictionary<string, AttributeValue>();
 
-			record.Add("State", AttributeValueHelper.StringOrNull (State));
-			record.Add("SchedulerInstanceId", AttributeValueHelper.StringOrNull (SchedulerInstanceId));
+            record.Add("State", AttributeValueHelper.StringOrNull (State));
+            record.Add("SchedulerInstanceId", AttributeValueHelper.StringOrNull (SchedulerInstanceId));
 
             record.Add("Name", AttributeValueHelper.StringOrNull(Trigger.Name));
             record.Add("Group", AttributeValueHelper.StringOrNull(Trigger.Group));
@@ -224,21 +224,21 @@ namespace Quartz.DynamoDB.DataModel
             record.Add("Description", AttributeValueHelper.StringOrNull(Trigger.Description));
             record.Add("CalendarName", AttributeValueHelper.StringOrNull(Trigger.CalendarName));
 
-			record.Add("JobDataMap",jobDataMapConverter.ToEntry(Trigger.JobDataMap));
+            record.Add("JobDataMap",_jobDataMapConverter.ToEntry(Trigger.JobDataMap));
             record.Add("MisfireInstruction", new AttributeValue() { N = Trigger.MisfireInstruction.ToString() });
             record.Add("FireInstanceId", AttributeValueHelper.StringOrNull(Trigger.FireInstanceId));
-            record.Add("StartTimeUtc", AttributeValueHelper.StringOrNull(Trigger.StartTimeUtc.ToString("yyyy-MM-ddTHH:mm:ss.fffffffzzz")));
-		
+            record.Add("StartTimeUtcEpoch", new AttributeValue() { N = _dateTimeOffsetConverter.ToEntry(Trigger.StartTimeUtc).ToString()});
+        
             if (Trigger.EndTimeUtc.HasValue)
             {
-                record.Add("EndTimeUtc", AttributeValueHelper.StringOrNull(Trigger.EndTimeUtc.Value.ToString("yyyy-MM-ddTHH:mm:ss.fffffffzzz")));
+                record.Add("EndTimeUtcEpoch", new AttributeValue() { N = _dateTimeOffsetConverter.ToEntry(Trigger.EndTimeUtc.Value).ToString() });
             }
 
-			if (Trigger.GetNextFireTimeUtc().HasValue)
-			{
-				record.Add("NextFireTimeUtcEpoch", new AttributeValue() { N = dateTimeOffsetConverter.ToEntry(Trigger.GetNextFireTimeUtc().Value).ToString()});
-				Debug.WriteLine("Storing Trigger NextFireTimeUTC {0}", Trigger.GetNextFireTimeUtc().Value);
-			}
+            if (Trigger.GetNextFireTimeUtc().HasValue)
+            {
+                record.Add("NextFireTimeUtcEpoch", new AttributeValue() { N = _dateTimeOffsetConverter.ToEntry(Trigger.GetNextFireTimeUtc().Value).ToString()});
+                Debug.WriteLine("Storing Trigger NextFireTimeUTC {0}", Trigger.GetNextFireTimeUtc().Value);
+            }
 
             record.Add("Priority", new AttributeValue() { N = Trigger.Priority.ToString() });
 
@@ -264,11 +264,11 @@ namespace Quartz.DynamoDB.DataModel
             else if (Trigger is DailyTimeIntervalTriggerImpl)
             {
                 DailyTimeIntervalTriggerImpl t = (DailyTimeIntervalTriggerImpl)Trigger;
-				if (Trigger.GetPreviousFireTimeUtc().HasValue)
-				{
-					record.Add("PreviousFireTimeUtcEpoch", new AttributeValue() { N = dateTimeOffsetConverter.ToEntry(Trigger.GetPreviousFireTimeUtc().Value).ToString()});
-				}                
-				record.Add("DaysOfWeek", new AttributeValue() { L = t.DaysOfWeek.Select(dow => new AttributeValue(dow.ToString())).ToList() });
+                if (Trigger.GetPreviousFireTimeUtc().HasValue)
+                {
+                    record.Add("PreviousFireTimeUtcEpoch", new AttributeValue() { N = _dateTimeOffsetConverter.ToEntry(Trigger.GetPreviousFireTimeUtc().Value).ToString()});
+                }                
+                record.Add("DaysOfWeek", new AttributeValue() { L = t.DaysOfWeek.Select(dow => new AttributeValue(dow.ToString())).ToList() });
                 record.Add("EndTimeOfDay_Hour", new AttributeValue() { N = t.EndTimeOfDay.Hour.ToString() });
                 record.Add("EndTimeOfDay_Minute", new AttributeValue() { N = t.EndTimeOfDay.Minute.ToString() });
                 record.Add("EndTimeOfDay_Second", new AttributeValue() { N = t.EndTimeOfDay.Second.ToString() });
@@ -290,11 +290,11 @@ namespace Quartz.DynamoDB.DataModel
                 record.Add("RepeatCount", new AttributeValue() { N = t.RepeatCount.ToString() });
                 record.Add("RepeatInterval", new AttributeValue() { N = t.RepeatInterval.Ticks.ToString() });
                 record.Add("TimesTriggered", new AttributeValue() { N = t.TimesTriggered.ToString() });
-				if (Trigger.GetPreviousFireTimeUtc().HasValue)
-				{
-					record.Add("PreviousFireTimeUtcEpoch", new AttributeValue() { N = dateTimeOffsetConverter.ToEntry(Trigger.GetPreviousFireTimeUtc().Value).ToString()});
-				} 
-				record.Add("Type", new AttributeValue() { S = "SimpleTriggerImpl" });
+                if (Trigger.GetPreviousFireTimeUtc().HasValue)
+                {
+                    record.Add("PreviousFireTimeUtcEpoch", new AttributeValue() { N = _dateTimeOffsetConverter.ToEntry(Trigger.GetPreviousFireTimeUtc().Value).ToString()});
+                } 
+                record.Add("Type", new AttributeValue() { S = "SimpleTriggerImpl" });
             }
 
             return record;

--- a/src/QuartzNET-DynamoDB/QuartzNET-DynamoDB.csproj
+++ b/src/QuartzNET-DynamoDB/QuartzNET-DynamoDB.csproj
@@ -66,6 +66,7 @@
     <Compile Include="..\VersionInfo.cs">
       <Link>Properties\VersionInfo.cs</Link>
     </Compile>
+    <Compile Include="DataModel\DateTimeConverter.cs" />
     <Compile Include="DataModel\DateTimeOffsetConverter.cs" />
     <Compile Include="DataModel\DynamoScheduler.cs" />
     <Compile Include="DataModel\UnixEpochDateTimeExtensions.cs" />
@@ -102,7 +103,5 @@
   <Target Name="AfterBuild">
   </Target>
   -->
-  <ItemGroup>
-    <Folder Include="DataModel\Storage\" />
-  </ItemGroup>
+  <ItemGroup />
 </Project>


### PR DESCRIPTION
#2 

There are 2 issues with this PR at the moment:
1) FinalFireTimeUtcSerializesCorrectly unit test fails as those times are now being stored as seconds since epoch, which means we no longer have millisecond precision. Therefore failures of the nature:

_Assert.Equal() Failure
      Expected: 2016-11-13T00:56:08.4226480+00:00
      Actual:   2016-11-13T00:56:08.0000000+00:00_

One way to overcome this would be to store milliseconds since epoch in dynamo and updating:
https://github.com/lukeryannetnz/quartznet-dynamodb/blob/master/src/QuartzNET-DynamoDB/DataModel/UnixEpochDateTimeExtensions.cs#L21

how do you think we should tackle this?

2) There is an issue with the unit test HolidayCalendarExcludedDays, which tests the serialization/deserialization of Excluded Dates in the Holiday Calendar.

This is due to the fact that storing datetimes as seconds since epoch means we lose the original timezone info associated with the DateTime object.

This leads to an assertion failure here
https://github.com/lukeryannetnz/quartznet-dynamodb/blob/master/src/QuartzNET-DynamoDB.Tests/Unit/CalendarSerialisationTests.cs#L123

as even though the expected date and the actual date are the same, one is of "Kind" local and the deserialized is of "Kind" UTC and the equality comparer isn't smart enough.

I've updated the unit test to only add dates of "Kind" UTC to the calendar as that is also what the quartz code seems to expect
https://github.com/quartznet/quartznet/blob/d3fe4060e323a5d87225119a540161f55f7b90d5/src/Quartz/Impl/Calendar/HolidayCalendar.cs#L205

Would you agree that updating the unit test was the right thing to do in this case?

(Note: PR build did not pick this up probably because local timezone for the build agent is UTC?)

@lukeryannetnz 

