### PR TITLE
Blocked Job and Trigger support

### DIFF
--- a/src/QuartzNET-DynamoDB.Tests/QuartzNET-DynamoDB.Tests.csproj
+++ b/src/QuartzNET-DynamoDB.Tests/QuartzNET-DynamoDB.Tests.csproj
@@ -118,6 +118,7 @@
     <Compile Include="Integration\JobStore\TriggerAddTests.cs" />
     <Compile Include="Integration\JobStore\TriggerGroupGetTests.cs" />
     <Compile Include="Integration\JobStore\JobResumeTests.cs" />
+    <Compile Include="Unit\DynamoJobTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="job_scheduling_data_2_0.xsd">

--- a/src/QuartzNET-DynamoDB.Tests/Unit/DynamoJobTests.cs
+++ b/src/QuartzNET-DynamoDB.Tests/Unit/DynamoJobTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Quartz.DynamoDB.DataModel;
+﻿using Quartz.DynamoDB.DataModel;
 using Xunit;
 
 namespace Quartz.DynamoDB.Tests

--- a/src/QuartzNET-DynamoDB.Tests/Unit/DynamoJobTests.cs
+++ b/src/QuartzNET-DynamoDB.Tests/Unit/DynamoJobTests.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using Quartz.DynamoDB.DataModel;
+using Xunit;
+
+namespace Quartz.DynamoDB.Tests
+{
+    /// <summary>
+    /// Contains tests for the dynamo job class.
+    /// </summary>
+    public class DynamoJobTests
+    {
+        public DynamoJobTests()
+        {
+        }
+
+        /// <summary>
+        /// Tests that a new DynamoJob object has its state set correctly.
+        /// </summary>
+        [Fact]
+        [Trait("Category", "Unit")]
+        public void InitialisedState()
+        {
+            var sut = new DynamoJob();
+
+            Assert.Equal(DynamoJobState.Active, sut.State);
+        }
+    }
+}

--- a/src/QuartzNET-DynamoDB/DataModel/DynamoJob.cs
+++ b/src/QuartzNET-DynamoDB/DataModel/DynamoJob.cs
@@ -3,6 +3,7 @@ using Amazon.DynamoDBv2.Model;
 using Quartz.Impl;
 using Quartz.Simpl;
 using Quartz.DynamoDB.DataModel.Storage;
+using System;
 
 namespace Quartz.DynamoDB.DataModel
 {
@@ -39,6 +40,7 @@ namespace Quartz.DynamoDB.DataModel
 			job.RequestsRecovery = record["RequestsRecovery"].BOOL;
 
 			Job = job;
+            State = (DynamoJobState)Enum.Parse(typeof(DynamoJobState), record["State"].S);
 		}
 
 		public string DynamoTableName  
@@ -59,6 +61,12 @@ namespace Quartz.DynamoDB.DataModel
 
         public IJobDetail Job { get; set; }
 
+        public DynamoJobState State
+        {
+            get;
+            set;
+        }
+
         public Dictionary<string, AttributeValue> ToDynamo()
         {
             Dictionary<string, AttributeValue> record = new Dictionary<string, AttributeValue>();
@@ -72,6 +80,7 @@ namespace Quartz.DynamoDB.DataModel
             record.Add("PersistJobDataAfterExecution", new AttributeValue { BOOL = Job.PersistJobDataAfterExecution });
             record.Add("ConcurrentExecutionDisallowed", new AttributeValue { BOOL = Job.ConcurrentExecutionDisallowed });
             record.Add("RequestsRecovery", new AttributeValue { BOOL = Job.RequestsRecovery });
+            record.Add("State", AttributeValueHelper.StringOrNull(State.ToString()));
 
             return record;
         }
@@ -80,5 +89,18 @@ namespace Quartz.DynamoDB.DataModel
         {
             return jobType.FullName + ", " + jobType.Assembly.GetName().Name;
         }
+    }
+
+    public enum DynamoJobState
+    {
+        /// <summary>
+        /// Indicates that the Job is Active.
+        /// </summary>
+        Active = 0,
+
+        /// <summary>
+        /// Indicates that the Job is Blocked.
+        /// </summary>
+        Blocked = 1,
     }
 }

--- a/src/QuartzNET-DynamoDB/DataModel/DynamoJob.cs
+++ b/src/QuartzNET-DynamoDB/DataModel/DynamoJob.cs
@@ -22,6 +22,7 @@ namespace Quartz.DynamoDB.DataModel
         public DynamoJob(IJobDetail job)
         {
             this.Job = job;
+            this.State = DynamoJobState.Active;
         }
 
         public DynamoJob(Dictionary<string, AttributeValue> record)

--- a/src/QuartzNET-DynamoDB/DataModel/DynamoJob.cs
+++ b/src/QuartzNET-DynamoDB/DataModel/DynamoJob.cs
@@ -101,6 +101,7 @@ namespace Quartz.DynamoDB.DataModel
 
         /// <summary>
         /// Indicates that the Job is Blocked.
+        /// A job is blocked when concurrent execution is disallowed and the job is being executed.
         /// </summary>
         Blocked = 1,
     }

--- a/src/QuartzNET-DynamoDB/DataModel/DynamoJob.cs
+++ b/src/QuartzNET-DynamoDB/DataModel/DynamoJob.cs
@@ -13,51 +13,51 @@ namespace Quartz.DynamoDB.DataModel
 	public class DynamoJob : IInitialisableFromDynamoRecord, IConvertibleToDynamoRecord, IDynamoTableType
     {
         private readonly SimpleTypeLoadHelper _typeHelper = new SimpleTypeLoadHelper();
-		private readonly JobDataMapConverter jobDataMapConverter = new JobDataMapConverter();
+        private readonly JobDataMapConverter jobDataMapConverter = new JobDataMapConverter();
 
-		public DynamoJob()
-		{
-		}
+        public DynamoJob()
+        {
+        }
 
         public DynamoJob(IJobDetail job)
         {
             this.Job = job;
         }
 
-		public DynamoJob(Dictionary<string, AttributeValue> record)
-		{
-			InitialiseFromDynamoRecord (record);
-		}
+        public DynamoJob(Dictionary<string, AttributeValue> record)
+        {
+            InitialiseFromDynamoRecord(record);
+        }
 
-		public void InitialiseFromDynamoRecord(Dictionary<string, AttributeValue> record)
-		{
-			JobDetailImpl job = new JobDetailImpl();
-			job.Key = new JobKey(record["Name"].S, record["Group"].S);
-			job.Description = record["Description"].NULL ? string.Empty : record["Description"].S;
-			job.JobType = _typeHelper.LoadType(record["JobType"].S);
-			job.JobDataMap = (JobDataMap)jobDataMapConverter.FromEntry(record["JobDataMap"]);
-			job.Durable = record["Durable"].BOOL;
-			job.RequestsRecovery = record["RequestsRecovery"].BOOL;
+        public void InitialiseFromDynamoRecord(Dictionary<string, AttributeValue> record)
+        {
+            JobDetailImpl job = new JobDetailImpl();
+            job.Key = new JobKey(record["Name"].S, record["Group"].S);
+            job.Description = record["Description"].NULL ? string.Empty : record["Description"].S;
+            job.JobType = _typeHelper.LoadType(record["JobType"].S);
+            job.JobDataMap = (JobDataMap)jobDataMapConverter.FromEntry(record["JobDataMap"]);
+            job.Durable = record["Durable"].BOOL;
+            job.RequestsRecovery = record["RequestsRecovery"].BOOL;
 
-			Job = job;
+            Job = job;
             State = (DynamoJobState)Enum.Parse(typeof(DynamoJobState), record["State"].S);
-		}
+        }
 
-		public string DynamoTableName  
-		{
-			get 
-			{
-				return DynamoConfiguration.JobDetailTableName;
-			}
-		}
+        public string DynamoTableName
+        {
+            get
+            {
+                return DynamoConfiguration.JobDetailTableName;
+            }
+        }
 
-		public Dictionary<string, AttributeValue> Key 
-		{ 
-			get 
-			{
-				return Job.Key.ToDictionary ();
-			}
-		}
+        public Dictionary<string, AttributeValue> Key
+        {
+            get
+            {
+                return Job.Key.ToDictionary();
+            }
+        }
 
         public IJobDetail Job { get; set; }
 
@@ -70,12 +70,12 @@ namespace Quartz.DynamoDB.DataModel
         public Dictionary<string, AttributeValue> ToDynamo()
         {
             Dictionary<string, AttributeValue> record = new Dictionary<string, AttributeValue>();
-            
+
             record.Add("Name", new AttributeValue { S = Job.Key.Name });
             record.Add("Group", new AttributeValue { S = Job.Key.Group });
             record.Add("Description", string.IsNullOrWhiteSpace(Job.Description) ? new AttributeValue { NULL = true } : new AttributeValue { S = Job.Description });
             record.Add("JobType", new AttributeValue { S = GetStorableJobTypeName(Job.JobType) });
-			record.Add("JobDataMap",jobDataMapConverter.ToEntry(Job.JobDataMap));
+            record.Add("JobDataMap", jobDataMapConverter.ToEntry(Job.JobDataMap));
             record.Add("Durable", new AttributeValue { BOOL = Job.Durable });
             record.Add("PersistJobDataAfterExecution", new AttributeValue { BOOL = Job.PersistJobDataAfterExecution });
             record.Add("ConcurrentExecutionDisallowed", new AttributeValue { BOOL = Job.ConcurrentExecutionDisallowed });

--- a/src/QuartzNET-DynamoDB/JobStore.cs
+++ b/src/QuartzNET-DynamoDB/JobStore.cs
@@ -843,15 +843,15 @@ namespace Quartz.DynamoDB
                 return;
             }
 
-            //todo: support blocked jobs
-            //if (this.BlockedJobs.FindOneByIdAs<BsonDocument>(trigger.JobKey.ToBsonDocument()) != null)
-            //{
-            //    triggerState["State"] = "Blocked";
-            //}
-            //else
-            //{
-            record.State = "Waiting";
-            //}
+            var job = _jobRepository.Load(record.Trigger.JobKey.ToDictionary());
+            if (job != null && job.State == DynamoJobState.Blocked)
+            {
+                record.State = "Blocked";
+            }
+            else
+            {
+                record.State = "Waiting";
+            }
 
             this.ApplyMisfireIfNecessary(record);
 

--- a/src/QuartzNET-DynamoDB/JobStore.cs
+++ b/src/QuartzNET-DynamoDB/JobStore.cs
@@ -1269,7 +1269,8 @@ namespace Quartz.DynamoDB
                             _triggerRepository.Store(jobTrigger);
                         }
 
-                        //todo: block the job
+                        storedJob.State = DynamoJobState.Blocked;
+                        _jobRepository.Store(storedJob);
                     }
 
                     results.Add(new TriggerFiredResult(bndle));

--- a/src/QuartzNET-DynamoDB/JobStore.cs
+++ b/src/QuartzNET-DynamoDB/JobStore.cs
@@ -263,7 +263,8 @@ namespace Quartz.DynamoDB
                     throw new ObjectAlreadyExistsException(newTrigger);
                 }
 
-                if (RetrieveJob(newTrigger.JobKey) == null)
+                var job = _jobRepository.Load(newTrigger.JobKey.ToDictionary());
+                if (job == null || job.Job == null)
                 {
                     throw new JobPersistenceException("The job (" + newTrigger.JobKey +
                     ") referenced by the trigger does not exist.");
@@ -305,21 +306,18 @@ namespace Quartz.DynamoDB
                     _jobGroupRepository.Store(jobGroup);
                 }
 
-                //todo: support blocked,PausedAndBlocked
-
-                //            if (this.PausedTriggerGroups.FindOneByIdAs<BsonDocument>(newTrigger.Key.Group) != null
-                //                || this.PausedJobGroups.FindOneByIdAs<BsonDocument>(newTrigger.JobKey.Group) != null)
-                //            {
-                //                state = "Paused";
-                //                if (this.BlockedJobs.FindOneByIdAs<BsonDocument>(newTrigger.JobKey.ToBsonDocument()) != null)
-                //                {
-                //                    state = "PausedAndBlocked";
-                //                }
-                //            }
-                //            else if (this.BlockedJobs.FindOneByIdAs<BsonDocument>(newTrigger.JobKey.ToBsonDocument()) != null)
-                //            {
-                //                state = "Blocked";
-                //            }
+                if (triggerGroup.State == DynamoTriggerGroup.DynamoTriggerGroupState.Paused
+                   || jobGroup.State == DynamoJobGroup.DynamoJobGroupState.Paused)
+                {
+                    if (job.State == DynamoJobState.Blocked)
+                    {
+                        trigger.State = "PausedAndBlocked";
+                    }
+                }
+                else if (job.State == DynamoJobState.Blocked)
+                {
+                    trigger.State = "Blocked";
+                }
 
                 _triggerRepository.Store(trigger);
             }
@@ -1319,10 +1317,11 @@ namespace Quartz.DynamoDB
                 _signaler.SignalSchedulingChange(null);
             }
 
-            //todo: Support blocked jobs
-            // even if it was deleted, there may be cleanup to do
-            //			this.BlockedJobs.Remove(
-            //				Query.EQ("_id", jobDetail.Key.ToBsonDocument()));
+            if (storedJob.State == DynamoJobState.Blocked)
+            {
+                storedJob.State = DynamoJobState.Active;
+                _jobRepository.Store(storedJob);
+            }
 
             // check for trigger deleted during execution...
             if (triggerInstCode == SchedulerInstruction.DeleteTrigger)


### PR DESCRIPTION
Resolves a number of todos per #7 

Feature parity with mongo store. As with other types, rather than having a collection of blocked jobs, introduced property on job type. 

Jobs seem to be blocked when they are running and disableconcurrentexecution=true to prevent multiple workers executing them. 

There is a lot of state-machine co-ordination spread around the place here, I feel like there is a more appropriate OOP/eventing style design - I haven't found it yet. It's really difficult to test - so I haven't. That's reason enough not to merge this off the bat in some respects. I've run out of time so submitting for review anyway, let me know what you think - I'll have a think about how to test this. 

cc @ddhi004 

