### PR TITLE
Publish to Nuget.org

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,9 +23,11 @@ platform:
 configuration: Release
 build:
   parallel: true                  
-  project: src\QuartzNET-DynamoDB.sln    
-after_build:
-  - nuget pack src\QuartzNET-DynamoDB\QuartzNET-DynamoDB.nuspec
+  project: src\QuartzNET-DynamoDB.sln   
+  publish_nuget: true 
+  publish_nuget_symbols: true     # generate and publish NuGet symbol packages
+  include_nuget_references: true  # add -IncludeReferencedProjects option while packaging NuGet artifacts
+
 #---------------------------------#
 #       test configuration        #
 #---------------------------------#
@@ -43,8 +45,7 @@ test:
     - QuartzNET-DynamoDB.Tests.dll
 
 artifacts:
-- path: src\QuartzNET-DynamoDB\*.nupkg
-  name: NuGet
+  - path: '**\*.nupkg'
 
 deploy:
   provider: NuGet

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,15 @@ environment:
 #---------------------------------#
 #       build configuration       #
 #---------------------------------#
+version: '{build}'
+pull_requests:
+  do_not_increment_build_number: true
+branches:
+  only:
+  - master
+nuget:
+  disable_publish_on_pr: true
+
 before_build:
   - nuget restore src\QuartzNET-DynamoDB.sln 
 platform:
@@ -15,7 +24,8 @@ configuration: Release
 build:
   parallel: true                  
   project: src\QuartzNET-DynamoDB.sln    
-
+after_build:
+  - nuget pack src\QuartzNET-DynamoDB\QuartzNET-DynamoDB.nuspec
 #---------------------------------#
 #       test configuration        #
 #---------------------------------#
@@ -31,3 +41,16 @@ before_test:
 test:
   assemblies: 
     - QuartzNET-DynamoDB.Tests.dll
+
+artifacts:
+- path: src\QuartzNET-DynamoDB\bin\Release\*.nupkg
+  name: NuGet
+
+deploy:
+  provider: NuGet
+  api_key:
+    secure: 2qbyIGUhwVPC5BpyWgLtgLNvc6DsblwAIuxTTEI0qXX3BF28+I35qoBILwB8Fe79
+  skip_symbols: false
+ on:
+    branch: master
+    appveyor_repo_tag: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -51,6 +51,6 @@ deploy:
   api_key:
     secure: 2qbyIGUhwVPC5BpyWgLtgLNvc6DsblwAIuxTTEI0qXX3BF28+I35qoBILwB8Fe79
   skip_symbols: false
- on:
+  on:
     branch: master
     appveyor_repo_tag: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -49,7 +49,7 @@ test:
     - QuartzNET-DynamoDB.Tests.dll
 
 artifacts:
-  - path: '**\*.nupkg'
+  - path: '**\QuartzNET*.nupkg'
 
 deploy:
   provider: NuGet

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,7 @@
+#---------------------------------------#
+#       environment configuration       #
+#---------------------------------------#
+
 #These are required by the AWS SDK even though they aren't used with dynamo db local.
 environment:
   AWS_ACCESS_KEY_ID: AKID
@@ -9,9 +13,13 @@ init:
 - ps: $env:buildVersion = "$env:packageVersion.$env:appveyor_build_number"
 - ps: $env:nugetVersion = "$env:packageVersion-beta-$env:appveyor_build_number"
 
-#---------------------------------#
-#       build configuration       #
-#---------------------------------#
+assembly_info:
+  patch: true
+  file: '**\VersionInfo.*'
+  assembly_version: '$(buildVersion)'
+  assembly_file_version: '$(buildVersion)'
+  assembly_informational_version: '$(nugetVersion)'
+
 pull_requests:
   do_not_increment_build_number: true
 branches:
@@ -20,6 +28,9 @@ branches:
 nuget:
   disable_publish_on_pr: true
 
+#---------------------------------#
+#       build configuration       #
+#---------------------------------#
 before_build:
   - nuget restore src\QuartzNET-DynamoDB.sln 
 platform:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,7 +43,7 @@ test:
     - QuartzNET-DynamoDB.Tests.dll
 
 artifacts:
-- path: src\QuartzNET-DynamoDB\bin\Release\*.nupkg
+- path: src\QuartzNET-DynamoDB\*.nupkg
   name: NuGet
 
 deploy:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,11 +3,15 @@ environment:
   AWS_ACCESS_KEY_ID: AKID
   AWS_SECRET_ACCESS_KEY: SECRET
   AWS_REGION: us-east-1
+  packageVersion: 0.1.0
+
+init:
+- ps: $env:buildVersion = "$env:packageVersion.$env:appveyor_build_number"
+- ps: $env:nugetVersion = "$env:packageVersion-beta-$env:appveyor_build_number"
 
 #---------------------------------#
 #       build configuration       #
 #---------------------------------#
-version: '{build}'
 pull_requests:
   do_not_increment_build_number: true
 branches:
@@ -24,9 +28,9 @@ configuration: Release
 build:
   parallel: true                  
   project: src\QuartzNET-DynamoDB.sln   
-  publish_nuget: true 
-  publish_nuget_symbols: true     # generate and publish NuGet symbol packages
-  include_nuget_references: true  # add -IncludeReferencedProjects option while packaging NuGet artifacts
+
+after_build:
+- ps: nuget pack src\QuartzNET-DynamoDB\QuartzNET-DynamoDB.nuspec -IncludeReferencedProjects -version "$env:nugetVersion"
 
 #---------------------------------#
 #       test configuration        #

--- a/src/QuartzNET-DynamoDB.sln
+++ b/src/QuartzNET-DynamoDB.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
-VisualStudioVersion = 14.0.23107.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QuartzNET-DynamoDB", "QuartzNET-DynamoDB\QuartzNET-DynamoDB.csproj", "{0834342B-7512-487B-829B-572F140655E8}"
 EndProject
@@ -33,8 +33,6 @@ Global
 		{40B8AE9E-ECFA-487E-920C-9890795E4764}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{40B8AE9E-ECFA-487E-920C-9890795E4764}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{40B8AE9E-ECFA-487E-920C-9890795E4764}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/QuartzNET-DynamoDB/QuartzNET-DynamoDB.csproj
+++ b/src/QuartzNET-DynamoDB/QuartzNET-DynamoDB.csproj
@@ -32,6 +32,8 @@
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <RunCodeAnalysis>true</RunCodeAnalysis>
+    <DocumentationFile>
+    </DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -97,6 +99,7 @@
       <SubType>Designer</SubType>
     </None>
     <None Include="packages.config" />
+    <None Include="QuartzNET-DynamoDB.nuspec" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
@@ -106,7 +109,5 @@
   <Target Name="AfterBuild">
   </Target>
   -->
-  <ItemGroup>
-    <Folder Include="DataModel\Storage\" />
-  </ItemGroup>
+  <ItemGroup />
 </Project>

--- a/src/QuartzNET-DynamoDB/QuartzNET-DynamoDB.nuspec
+++ b/src/QuartzNET-DynamoDB/QuartzNET-DynamoDB.nuspec
@@ -13,14 +13,6 @@
 
       This library provides a fully functioning Amazon DynamoDB JobStore for Quartz.NET using the AWS SDK Dynamo client.
     </description>
-    <dependencies>
-      <dependency id="AWSSDK.Core" version="3.1.6.0" />
-      <dependency id="AWSSDK.DynamoDBv2" version="3.1.4.1" />
-      <dependency id="Common.Logging" version="3.3.1" />
-      <dependency id="Common.Logging.Core" version="3.3.1" />
-      <dependency id="Newtonsoft.Json" version="8.0.3" />
-      <dependency id="Quartz" version="2.3.3" />
-    </dependencies>
   </metadata>
   <files>
     <file src="bin\Release\QuartzNET-DynamoDB.dll" target="lib\net45" />

--- a/src/QuartzNET-DynamoDB/QuartzNET-DynamoDB.nuspec
+++ b/src/QuartzNET-DynamoDB/QuartzNET-DynamoDB.nuspec
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>QuartzNet-DynamoDB</id>
+    <version>0.0.0.0</version>
+    <title>QuartzNET-DynamoDB</title>
+    <authors>Luke Ryan, Dhruv Dhir</authors>
+    <licenseUrl>https://github.com/lukeryannetnz/quartznet-dynamodb/blob/master/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/lukeryannetnz/quartznet-dynamodb</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>
+      Quartz.NET Quartz.NET is a full-featured, open source job scheduling system that can be used from smallest apps to large scale enterprise systems.
+
+      This library provides a fully functioning Amazon DynamoDB JobStore for Quartz.NET using the AWS SDK Dynamo client.
+    </description>
+    <dependencies>
+      <dependency id="AWSSDK.Core" version="3.1.6.0" />
+      <dependency id="AWSSDK.DynamoDBv2" version="3.1.4.1" />
+      <dependency id="Common.Logging" version="3.3.1" />
+      <dependency id="Common.Logging.Core" version="3.3.1" />
+      <dependency id="Newtonsoft.Json" version="8.0.3" />
+      <dependency id="Quartz" version="2.3.3" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="bin\Release\QuartzNET-DynamoDB.dll" target="lib\net45" />
+    <file src="bin\release\QuartzNET-DynamoDB.pdb" target="lib\net45" />
+  </files>
+</package>


### PR DESCRIPTION
#31

## Added .nuspec for primary library. 
- Included references, suspect there is a better way to do this that wouldn't require updating in two places (packages.config and here). Any ideas @ddhi004?
    * Update: found that nuget can do this for you automatically based on references with the includereferencedprojects flag, which is set by appveyor with the build setting include_nuget_references: true 
    * Updated update: Found that this didn't set the version of the nuget package correctly. Followed instructions on this SO to set explicitly: http://stackoverflow.com/questions/34273570/how-to-publish-beta-nuget-packages-out-of-appveyor
* Updated appveyor build to:
    * stop building for non-master or PR branches
    * package nuspec after building
    * publish to nuget.org
    * Print the version number on the assemblies via VersionInfo.cs file.

### Possible improvements
* Could include some .config file transformations in the nuget package to set the config file up how we need it, although this is really just how the AWS library requires it.