### PR TITLE
Remove condition preventing publishing of nuget package

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -69,4 +69,3 @@ deploy:
   skip_symbols: false
   on:
     branch: master
-    appveyor_repo_tag: true


### PR DESCRIPTION
#31 

<img width="1037" alt="screen shot 2017-02-19 at 6 56 56 pm" src="https://cloud.githubusercontent.com/assets/372207/23099868/4f58b3ae-f6d5-11e6-9130-b5f87ad62cf2.png">

Nuget package wasn't being published because of a condition in the appveyor configuration file. This PR removes that condition which should result in packages publishing!