### PR TITLE
Todo, document fired trigger record counter variable.

### DIFF
--- a/src/QuartzNET-DynamoDB.Tests/Integration/JobStore/SchedulerIntegrationTests.cs
+++ b/src/QuartzNET-DynamoDB.Tests/Integration/JobStore/SchedulerIntegrationTests.cs
@@ -15,13 +15,13 @@ namespace Quartz.DynamoDB.Tests.Integration.JobStore
             _sut = _testFactory.CreateTestJobStore();
         }
 
-        [Fact]
-        [Trait("Category", "Integration")]
         /// <summary>
         /// Ensures that only one scheduler record is created by the jobstore.
         /// Tests common JobStore methods that interact with the scheduler.
         /// </summary>
-        public void SingleSchedulerCreated()
+        [Fact]
+        [Trait("Category", "Integration")]
+         public void SingleSchedulerCreated()
         {
             var signaler = new Quartz.DynamoDB.Tests.Integration.RamJobStoreTests.SampleSignaler();
             var loadHelper = new SimpleTypeLoadHelper();

--- a/src/QuartzNET-DynamoDB.Tests/Integration/Repository/RepositoryTests.cs
+++ b/src/QuartzNET-DynamoDB.Tests/Integration/Repository/RepositoryTests.cs
@@ -51,6 +51,9 @@ namespace Quartz.DynamoDB.Tests.Integration.Repository
             Assert.Equal(initialSchedulerCount + 1, finalCount);
         }
 
+        /// <summary>
+        /// Tests the repository Store method that wraps the Dynamo BatchWriteItem API.
+        /// </summary>
         [Fact]
         [Trait("Category", "Integration")]
         public void StoreMultipleEntities()

--- a/src/QuartzNET-DynamoDB.Tests/Integration/Repository/RepositoryTests.cs
+++ b/src/QuartzNET-DynamoDB.Tests/Integration/Repository/RepositoryTests.cs
@@ -57,7 +57,7 @@ namespace Quartz.DynamoDB.Tests.Integration.Repository
         /// </summary>
         [Fact]
         [Trait("Category", "Integration")]
-        public void StoreTwentyFiveMultipleEntities()
+        public void StoreTwentyFiveEntities()
         {
             _testFactory = new DynamoClientFactory();
             var client = _testFactory.BootStrapDynamo();
@@ -92,7 +92,7 @@ namespace Quartz.DynamoDB.Tests.Integration.Repository
         /// </summary>
         [Fact]
         [Trait("Category", "Integration")]
-        public void StoreTwentySixMultipleEntities()
+        public void StoreTwentySixEntities()
         {
             _testFactory = new DynamoClientFactory();
             var client = _testFactory.BootStrapDynamo();

--- a/src/QuartzNET-DynamoDB.Tests/Integration/Repository/RepositoryTests.cs
+++ b/src/QuartzNET-DynamoDB.Tests/Integration/Repository/RepositoryTests.cs
@@ -51,6 +51,37 @@ namespace Quartz.DynamoDB.Tests.Integration.Repository
             Assert.Equal(initialSchedulerCount + 1, finalCount);
         }
 
+        [Fact]
+        [Trait("Category", "Integration")]
+        public void StoreMultipleEntities()
+        {
+            _testFactory = new DynamoClientFactory();
+            var client = _testFactory.BootStrapDynamo();
+            _sut = new Repository<DynamoScheduler>(client);
+
+            int initialSchedulerCount = _sut.Scan(null, null, null).Count();
+
+            var scheduler1 = new DynamoScheduler
+            {
+                InstanceId = "testInstance" + DateTime.UtcNow.Ticks.ToString(),
+                ExpiresUtc = (SystemTime.Now() + new TimeSpan(0, 10, 0)).UtcDateTime,
+                State = "Running"
+            };
+
+            var scheduler2 = new DynamoScheduler
+            {
+                InstanceId = "testInstance2" + DateTime.UtcNow.Ticks.ToString(),
+                ExpiresUtc = (SystemTime.Now() + new TimeSpan(0, 10, 0)).UtcDateTime,
+                State = "Running"
+            };
+
+            _sut.Store(new List<DynamoScheduler> {scheduler1, scheduler2});
+
+            int finalCount = _sut.Scan(null, null, null).Count();
+
+            Assert.Equal(initialSchedulerCount + 2, finalCount);
+        }
+
         #region IDisposable implementation
 
         bool _disposedValue = false;

--- a/src/QuartzNET-DynamoDB.Tests/Integration/Repository/RepositoryTests.cs
+++ b/src/QuartzNET-DynamoDB.Tests/Integration/Repository/RepositoryTests.cs
@@ -53,40 +53,6 @@ namespace Quartz.DynamoDB.Tests.Integration.Repository
 
         /// <summary>
         /// Tests the repository Store method that wraps the Dynamo BatchWriteItem API.
-        /// </summary>
-        [Fact]
-        [Trait("Category", "Integration")]
-        public void StoreMultipleEntities()
-        {
-            _testFactory = new DynamoClientFactory();
-            var client = _testFactory.BootStrapDynamo();
-            _sut = new Repository<DynamoScheduler>(client);
-
-            int initialSchedulerCount = _sut.Scan(null, null, null).Count();
-
-            var scheduler1 = new DynamoScheduler
-            {
-                InstanceId = "testInstance" + DateTime.UtcNow.Ticks.ToString(),
-                ExpiresUtc = (SystemTime.Now() + new TimeSpan(0, 10, 0)).UtcDateTime,
-                State = "Running"
-            };
-
-            var scheduler2 = new DynamoScheduler
-            {
-                InstanceId = "testInstance2" + DateTime.UtcNow.Ticks.ToString(),
-                ExpiresUtc = (SystemTime.Now() + new TimeSpan(0, 10, 0)).UtcDateTime,
-                State = "Running"
-            };
-
-            _sut.Store(new List<DynamoScheduler> {scheduler1, scheduler2});
-
-            int finalCount = _sut.Scan(null, null, null).Count();
-
-            Assert.Equal(initialSchedulerCount + 2, finalCount);
-        }
-
-        /// <summary>
-        /// Tests the repository Store method that wraps the Dynamo BatchWriteItem API.
         /// 25 is the maximum number of items for one batch.
         /// </summary>
         [Fact]

--- a/src/QuartzNET-DynamoDB.Tests/Integration/Repository/RepositoryTests.cs
+++ b/src/QuartzNET-DynamoDB.Tests/Integration/Repository/RepositoryTests.cs
@@ -85,6 +85,76 @@ namespace Quartz.DynamoDB.Tests.Integration.Repository
             Assert.Equal(initialSchedulerCount + 2, finalCount);
         }
 
+        /// <summary>
+        /// Tests the repository Store method that wraps the Dynamo BatchWriteItem API.
+        /// 25 is the maximum number of items for one batch.
+        /// </summary>
+        [Fact]
+        [Trait("Category", "Integration")]
+        public void StoreTwentyFiveMultipleEntities()
+        {
+            _testFactory = new DynamoClientFactory();
+            var client = _testFactory.BootStrapDynamo();
+            _sut = new Repository<DynamoScheduler>(client);
+
+            int initialSchedulerCount = _sut.Scan(null, null, null).Count();
+
+            var items = new List<DynamoScheduler>();
+
+            for (int i = 0; i < 25; i++)
+            {
+                var scheduler = new DynamoScheduler
+                {
+                    InstanceId = "testInstance" + DateTime.UtcNow.Ticks.ToString() + i,
+                    ExpiresUtc = (SystemTime.Now() + new TimeSpan(0, 10, 0)).UtcDateTime,
+                    State = "Running"
+                };
+
+                items.Add(scheduler);
+            }
+          
+            _sut.Store(items);
+
+            int finalCount = _sut.Scan(null, null, null).Count();
+
+            Assert.Equal(initialSchedulerCount + 25, finalCount);
+        }
+
+        /// <summary>
+        /// Tests the repository Store method that wraps the Dynamo BatchWriteItem API.
+        /// 26 is enough items for two batches.
+        /// </summary>
+        [Fact]
+        [Trait("Category", "Integration")]
+        public void StoreTwentySixMultipleEntities()
+        {
+            _testFactory = new DynamoClientFactory();
+            var client = _testFactory.BootStrapDynamo();
+            _sut = new Repository<DynamoScheduler>(client);
+
+            int initialSchedulerCount = _sut.Scan(null, null, null).Count();
+
+            var items = new List<DynamoScheduler>();
+
+            for (int i = 0; i < 26; i++)
+            {
+                var scheduler = new DynamoScheduler
+                {
+                    InstanceId = "testInstance" + DateTime.UtcNow.Ticks.ToString() + i,
+                    ExpiresUtc = (SystemTime.Now() + new TimeSpan(0, 10, 0)).UtcDateTime,
+                    State = "Running"
+                };
+
+                items.Add(scheduler);
+            }
+
+            _sut.Store(items);
+
+            int finalCount = _sut.Scan(null, null, null).Count();
+
+            Assert.Equal(initialSchedulerCount + 26, finalCount);
+        }
+
         #region IDisposable implementation
 
         bool _disposedValue = false;

--- a/src/QuartzNET-DynamoDB/DataModel/Storage/IRepository.cs
+++ b/src/QuartzNET-DynamoDB/DataModel/Storage/IRepository.cs
@@ -21,17 +21,26 @@ namespace Quartz.DynamoDB.DataModel.Storage
 		/// <param name="entity">Entity.</param>
 		void Store (T entity);
 
-		/// <summary>
-		/// Store the specified entity, in the table T is associated with. 
-		/// Only store the specific entity is the condition specified in conditionExpression is met..
-		/// See dynamo docs for more details on conditions http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.SpecifyingConditions.html
+        /// <summary>
+		/// Store the specified entities in the table T is associated with.
 		/// </summary>
-		/// <param name="entity">Entity.</param>
-		/// <param name="expressionAttributeValues">Expression attribute values. <see cref="http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ExpressionPlaceholders.html"/></param>
-		/// <param name="conditionExpression">Condition expression. <see cref="http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_PutItem.html#DDB-PutItem-request-ConditionExpression"/></param>
-		/// <param name="expressionAttributeNames">Expression attribute names. <see cref="http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_PutItem.html#DDB-PutItem-request-ExpressionAttributeNames"/></param>
-		/// <returns>>ALL_OLD the values that were replaced. <see cref="http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_PutItem.html#DDB-PutItem-request-ReturnValues"/> </returns>
-		Dictionary<string,AttributeValue> Store(T entity, Dictionary<string,AttributeValue> expressionAttributeValues, Dictionary<string, string> expressionAttributeNames, string conditionExpression);
+		/// <param name="entities">The entities to store.</param>
+		/// <exception cref="ArgumentNullException">Thrown if entities is null.</exception>
+		/// <exception cref="ArgumentOutOfRangeException">Thrown if there are no items in the entities collection OR if there are more than 25 items in the entities collection.</exception>
+		/// <exception cref="JobPersistenceException">Thrown if a non 200 HTTP code is received from DynamoDB.</exception>
+		void Store(IEnumerable<T> entities);
+
+        /// <summary>
+        /// Store the specified entity, in the table T is associated with. 
+        /// Only store the specific entity is the condition specified in conditionExpression is met..
+        /// See dynamo docs for more details on conditions http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.SpecifyingConditions.html
+        /// </summary>
+        /// <param name="entity">Entity.</param>
+        /// <param name="expressionAttributeValues">Expression attribute values. <see cref="http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ExpressionPlaceholders.html"/></param>
+        /// <param name="conditionExpression">Condition expression. <see cref="http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_PutItem.html#DDB-PutItem-request-ConditionExpression"/></param>
+        /// <param name="expressionAttributeNames">Expression attribute names. <see cref="http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_PutItem.html#DDB-PutItem-request-ExpressionAttributeNames"/></param>
+        /// <returns>>ALL_OLD the values that were replaced. <see cref="http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_PutItem.html#DDB-PutItem-request-ReturnValues"/> </returns>
+        Dictionary<string,AttributeValue> Store(T entity, Dictionary<string,AttributeValue> expressionAttributeValues, Dictionary<string, string> expressionAttributeNames, string conditionExpression);
 
 		/// <summary>
 		/// Delete the entity with the specified key.

--- a/src/QuartzNET-DynamoDB/DataModel/Storage/IRepository.cs
+++ b/src/QuartzNET-DynamoDB/DataModel/Storage/IRepository.cs
@@ -8,18 +8,18 @@ namespace Quartz.DynamoDB.DataModel.Storage
     /// Deals with storing and retrieving Dynamo records from the Dynamo api.
     /// </summary>
     interface IRepository<T> : IDisposable
-	{
-		/// <summary>
-		/// Load a single record of type T from the table T is associated with, matching the provided Key.
-		/// </summary>
-		/// <param name="key">Key.</param>
-		T Load (Dictionary<string, AttributeValue> key);
+    {
+        /// <summary>
+        /// Load a single record of type T from the table T is associated with, matching the provided Key.
+        /// </summary>
+        /// <param name="key">Key.</param>
+        T Load(Dictionary<string, AttributeValue> key);
 
-		/// <summary>
-		/// Store the specified entity in the table T is associated with.
-		/// </summary>
-		/// <param name="entity">Entity.</param>
-		void Store (T entity);
+        /// <summary>
+        /// Store the specified entity in the table T is associated with.
+        /// </summary>
+        /// <param name="entity">Entity.</param>
+        void Store(T entity);
 
         /// <summary>
 		/// Store the specified entities in the table T is associated with.
@@ -40,34 +40,34 @@ namespace Quartz.DynamoDB.DataModel.Storage
         /// <param name="conditionExpression">Condition expression. <see cref="http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_PutItem.html#DDB-PutItem-request-ConditionExpression"/></param>
         /// <param name="expressionAttributeNames">Expression attribute names. <see cref="http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_PutItem.html#DDB-PutItem-request-ExpressionAttributeNames"/></param>
         /// <returns>>ALL_OLD the values that were replaced. <see cref="http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_PutItem.html#DDB-PutItem-request-ReturnValues"/> </returns>
-        Dictionary<string,AttributeValue> Store(T entity, Dictionary<string,AttributeValue> expressionAttributeValues, Dictionary<string, string> expressionAttributeNames, string conditionExpression);
+        Dictionary<string, AttributeValue> Store(T entity, Dictionary<string, AttributeValue> expressionAttributeValues, Dictionary<string, string> expressionAttributeNames, string conditionExpression);
 
-		/// <summary>
-		/// Delete the entity with the specified key.
-		/// </summary>
-		/// <param name="key">Key.</param>
-		void Delete (Dictionary<string, AttributeValue> key);
+        /// <summary>
+        /// Delete the entity with the specified key.
+        /// </summary>
+        /// <param name="key">Key.</param>
+        void Delete(Dictionary<string, AttributeValue> key);
 
-		/// <summary>
-		/// Scan the table with the provided expressionAttributeValues and filterExpression.
-		/// <see cref="http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Scan.html"/> 
-		/// </summary>
-		/// <param name="expressionAttributeValues">Expression attribute values. <see cref="http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ExpressionPlaceholders.html"/></param>
-		/// <param name="filterExpression">Filter expression. <see cref="http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/QueryAndScan.html#FilteringResults"/></param>
-		/// <param name="expressionAttributeNames">Expression attribute names. <see cref="http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_PutItem.html#DDB-PutItem-request-ExpressionAttributeNames"/></param>
-		IEnumerable<T> Scan (Dictionary<string,AttributeValue> expressionAttributeValues, Dictionary<string, string> expressionAttributeNames, string filterExpression);
+        /// <summary>
+        /// Scan the table with the provided expressionAttributeValues and filterExpression.
+        /// <see cref="http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Scan.html"/> 
+        /// </summary>
+        /// <param name="expressionAttributeValues">Expression attribute values. <see cref="http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ExpressionPlaceholders.html"/></param>
+        /// <param name="filterExpression">Filter expression. <see cref="http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/QueryAndScan.html#FilteringResults"/></param>
+        /// <param name="expressionAttributeNames">Expression attribute names. <see cref="http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_PutItem.html#DDB-PutItem-request-ExpressionAttributeNames"/></param>
+        IEnumerable<T> Scan(Dictionary<string, AttributeValue> expressionAttributeValues, Dictionary<string, string> expressionAttributeNames, string filterExpression);
 
-		/// <summary>
-		/// Deletes the table. This permanently deletes ALL DATA in the table!
-		/// </summary>
-		void DeleteTable();
+        /// <summary>
+        /// Deletes the table. This permanently deletes ALL DATA in the table!
+        /// </summary>
+        void DeleteTable();
 
-		/// <summary>
-		/// Returns information about the table, including the current status of the table, when it was created, the primary key schema, and any indexes on the table.
-		/// <see cref="http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_DescribeTable.html"/> 
-		/// </summary>
-		/// <returns>The table.</returns>
-		DescribeTableResponse DescribeTable();
-	}
+        /// <summary>
+        /// Returns information about the table, including the current status of the table, when it was created, the primary key schema, and any indexes on the table.
+        /// <see cref="http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_DescribeTable.html"/> 
+        /// </summary>
+        /// <returns>The table.</returns>
+        DescribeTableResponse DescribeTable();
+    }
 }
 

--- a/src/QuartzNET-DynamoDB/DataModel/Storage/IRepository.cs
+++ b/src/QuartzNET-DynamoDB/DataModel/Storage/IRepository.cs
@@ -26,9 +26,9 @@ namespace Quartz.DynamoDB.DataModel.Storage
 		/// </summary>
 		/// <param name="entities">The entities to store.</param>
 		/// <exception cref="ArgumentNullException">Thrown if entities is null.</exception>
-		/// <exception cref="ArgumentOutOfRangeException">Thrown if there are no items in the entities collection OR if there are more than 25 items in the entities collection.</exception>
+		/// <exception cref="ArgumentOutOfRangeException">Thrown if there are no items in the entities collection.</exception>
 		/// <exception cref="JobPersistenceException">Thrown if a non 200 HTTP code is received from DynamoDB.</exception>
-		void Store(IEnumerable<T> entities);
+		void Store(IList<T> entities);
 
         /// <summary>
         /// Store the specified entity, in the table T is associated with. 

--- a/src/QuartzNET-DynamoDB/DataModel/Storage/Repository.cs
+++ b/src/QuartzNET-DynamoDB/DataModel/Storage/Repository.cs
@@ -62,15 +62,15 @@ namespace Quartz.DynamoDB.DataModel.Storage
             }
 
             List<T> batch = new List<T>();
-            for (int i = 0; i < entities.Count(); i++)
+            for (int i = 1; i <= entities.Count(); i++)
             {
                 batch.Add(entities[i]);
-                if (i + 1 == entities.Count())
+                if (i == entities.Count())
                 {
                     // If we've reached the end of the collection, send off the save request
                     SendBatchWriteRequest(batch);
                 }
-                else if (i > 0 && (i + 1) % 25 == 0)
+                else if (i % 25 == 0)
                 {
                     // If we've reached a factor of 25, send off the save request.
                     SendBatchWriteRequest(batch);

--- a/src/QuartzNET-DynamoDB/DataModel/Storage/Repository.cs
+++ b/src/QuartzNET-DynamoDB/DataModel/Storage/Repository.cs
@@ -70,7 +70,7 @@ namespace Quartz.DynamoDB.DataModel.Storage
                     // If we've reached the end of the collection, send off the save request
                     SendBatchWriteRequest(batch);
                 }
-                else if (i % 25 == 0)
+                else if (i > 0 && (i + 1) % 25 == 0)
                 {
                     // If we've reached a factor of 25, send off the save request.
                     SendBatchWriteRequest(batch);

--- a/src/QuartzNET-DynamoDB/DataModel/Storage/Repository.cs
+++ b/src/QuartzNET-DynamoDB/DataModel/Storage/Repository.cs
@@ -64,7 +64,7 @@ namespace Quartz.DynamoDB.DataModel.Storage
             List<T> batch = new List<T>();
             for (int i = 1; i <= entities.Count(); i++)
             {
-                batch.Add(entities[i]);
+                batch.Add(entities[i - 1]);
                 if (i == entities.Count())
                 {
                     // If we've reached the end of the collection, send off the save request

--- a/src/QuartzNET-DynamoDB/JobStore.cs
+++ b/src/QuartzNET-DynamoDB/JobStore.cs
@@ -1385,7 +1385,6 @@ namespace Quartz.DynamoDB
             }
 
             _triggerRepository.Store(dynamoTriggers);
-
         }
 
         /// <summary> 

--- a/src/QuartzNET-DynamoDB/JobStore.cs
+++ b/src/QuartzNET-DynamoDB/JobStore.cs
@@ -21,7 +21,7 @@ namespace Quartz.DynamoDB
     /// </summary>
     public class JobStore : IJobStore, IDisposable
     {
-        private static readonly object lockObject = new object();
+        private static readonly object LockObject = new object();
         private DynamoDBContext _context;
         private IRepository<DynamoJob> _jobRepository;
         private IRepository<DynamoJobGroup> _jobGroupRepository;
@@ -61,7 +61,7 @@ namespace Quartz.DynamoDB
             _triggerGroupRepository = new Repository<DynamoTriggerGroup>(client);
             _calendarRepository = new Repository<DynamoCalendar>(client);
 
-            lock (lockObject)
+            lock (LockObject)
             {
                 new DynamoBootstrapper().BootStrap(client);
 
@@ -78,7 +78,7 @@ namespace Quartz.DynamoDB
 
         public void SchedulerStarted()
         {
-            lock (lockObject)
+            lock (LockObject)
             {
                 CreateOrUpdateCurrentSchedulerInstance();
             }
@@ -110,7 +110,7 @@ namespace Quartz.DynamoDB
 
         public void StoreJobAndTrigger(IJobDetail newJob, IOperableTrigger newTrigger)
         {
-            lock (lockObject)
+            lock (LockObject)
             {
                 StoreJob(newJob, false);
                 StoreTrigger(newTrigger, false);
@@ -143,7 +143,7 @@ namespace Quartz.DynamoDB
 
         public void StoreJob(IJobDetail newJob, bool replaceExisting)
         {
-            lock (lockObject)
+            lock (LockObject)
             {
                 DynamoJob job = new DynamoJob(newJob);
 
@@ -172,7 +172,7 @@ namespace Quartz.DynamoDB
         public void StoreJobsAndTriggers(IDictionary<IJobDetail, Collection.ISet<ITrigger>> triggersAndJobs,
                                          bool replace)
         {
-            lock (lockObject)
+            lock (LockObject)
             {
                 // fail fast if there are collisions.
                 // ensuring there will be no collisions upfront eliminates the need
@@ -208,7 +208,7 @@ namespace Quartz.DynamoDB
 
         public bool RemoveJob(JobKey jobKey)
         {
-            lock (lockObject)
+            lock (LockObject)
             {
                 // keep separated to clean up any staled trigger
                 IList<IOperableTrigger> triggersForJob = this.GetTriggersForJob(jobKey);
@@ -231,7 +231,7 @@ namespace Quartz.DynamoDB
         {
             bool allFound = true;
 
-            lock (lockObject)
+            lock (LockObject)
             {
                 foreach (JobKey key in jobKeys)
                 {
@@ -244,7 +244,7 @@ namespace Quartz.DynamoDB
 
         public IJobDetail RetrieveJob(JobKey jobKey)
         {
-            lock (lockObject)
+            lock (LockObject)
             {
                 var job = _jobRepository.Load(jobKey.ToDictionary());
 
@@ -254,7 +254,7 @@ namespace Quartz.DynamoDB
 
         public void StoreTrigger(IOperableTrigger newTrigger, bool replaceExisting)
         {
-            lock (lockObject)
+            lock (LockObject)
             {
                 DynamoTrigger trigger = new DynamoTrigger(newTrigger);
 
@@ -327,7 +327,7 @@ namespace Quartz.DynamoDB
         {
             bool found;
 
-            lock (lockObject)
+            lock (LockObject)
             {
                 var trigger = this.RetrieveTrigger(triggerKey);
                 found = trigger != null;
@@ -361,7 +361,7 @@ namespace Quartz.DynamoDB
         {
             bool allFound = true;
 
-            lock (lockObject)
+            lock (LockObject)
             {
                 foreach (TriggerKey key in triggerKeys)
                 {
@@ -374,7 +374,7 @@ namespace Quartz.DynamoDB
 
         public bool ReplaceTrigger(TriggerKey triggerKey, IOperableTrigger newTrigger)
         {
-            lock (lockObject)
+            lock (LockObject)
             {
                 var record = _triggerRepository.Load(triggerKey.ToDictionary());
 
@@ -406,7 +406,7 @@ namespace Quartz.DynamoDB
 
         public IOperableTrigger RetrieveTrigger(TriggerKey triggerKey)
         {
-            lock (lockObject)
+            lock (LockObject)
             {
                 var trigger = _triggerRepository.Load(triggerKey.ToDictionary());
 
@@ -416,7 +416,7 @@ namespace Quartz.DynamoDB
 
         public bool CalendarExists(string calName)
         {
-            lock (lockObject)
+            lock (LockObject)
             {
                 var key = new DynamoCalendar(calName).Key;
 
@@ -426,7 +426,7 @@ namespace Quartz.DynamoDB
 
         public bool CheckExists(JobKey jobKey)
         {
-            lock (lockObject)
+            lock (LockObject)
             {
                 return _jobRepository.Load(jobKey.ToDictionary()) != null;
             }
@@ -434,7 +434,7 @@ namespace Quartz.DynamoDB
 
         public bool CheckExists(TriggerKey triggerKey)
         {
-            lock (lockObject)
+            lock (LockObject)
             {
                 return _triggerRepository.Load(triggerKey.ToDictionary()) != null;
             }
@@ -446,7 +446,7 @@ namespace Quartz.DynamoDB
         /// </summary>
         public void ClearAllSchedulingData()
         {
-            lock (lockObject)
+            lock (LockObject)
             {
                 // unschedule jobs (delete triggers)
                 _triggerRepository.DeleteTable();
@@ -475,7 +475,7 @@ namespace Quartz.DynamoDB
         /// re-computed with the new <see cref="ICalendar" />.</param>
         public void StoreCalendar(string name, ICalendar calendar, bool replaceExisting, bool updateTriggers)
         {
-            lock (lockObject)
+            lock (LockObject)
             {
                 var dynamoCal = new DynamoCalendar(name, calendar);
 
@@ -639,7 +639,7 @@ namespace Quartz.DynamoDB
 
         public TriggerState GetTriggerState(TriggerKey triggerKey)
         {
-            lock (lockObject)
+            lock (LockObject)
             {
                 var record = _triggerRepository.Load(triggerKey.ToDictionary());
 
@@ -894,7 +894,7 @@ namespace Quartz.DynamoDB
 
         public void ResumeJob(JobKey jobKey)
         {
-            lock (lockObject)
+            lock (LockObject)
             {
                 IList<IOperableTrigger> triggersForJob = GetTriggersForJob(jobKey);
                 foreach (IOperableTrigger trigger in triggersForJob)
@@ -941,7 +941,7 @@ namespace Quartz.DynamoDB
 
         public void PauseAll()
         {
-            lock (lockObject)
+            lock (LockObject)
             {
                 var triggerGroupNames = GetTriggerGroupNames();
 
@@ -954,7 +954,7 @@ namespace Quartz.DynamoDB
 
         public void ResumeAll()
         {
-            lock (lockObject)
+            lock (LockObject)
             {
                 var triggerGroupNames = GetTriggerGroupNames();
 
@@ -984,12 +984,11 @@ namespace Quartz.DynamoDB
 
         public IList<IOperableTrigger> AcquireNextTriggers(DateTimeOffset noLaterThan, int maxCount, TimeSpan timeWindow)
         {
-            lock (lockObject)
+            lock (LockObject)
             {
                 Debug.WriteLine("Acquiring triggers. No later than: {0}, timewindow: {1}", noLaterThan, timeWindow);
 
                 // multiple instance management. Create a running scheduler for this instance.
-                // TODO: investigate: does this create duplicate active schedulers for the same instanceid?
                 CreateOrUpdateCurrentSchedulerInstance();
 
                 DeleteExpiredSchedulers();
@@ -1177,7 +1176,7 @@ namespace Quartz.DynamoDB
 
         public IList<TriggerFiredResult> TriggersFired(IList<IOperableTrigger> triggers)
         {
-            lock (lockObject)
+            lock (LockObject)
             {
                 List<TriggerFiredResult> results = new List<TriggerFiredResult>();
 

--- a/src/QuartzNET-DynamoDB/JobStore.cs
+++ b/src/QuartzNET-DynamoDB/JobStore.cs
@@ -967,14 +967,15 @@ namespace Quartz.DynamoDB
 
         /// <summary>
         /// A counter for fired trigger records.
-        /// TODO: put something here that explains what this does.
+        /// A unique value that initialises as the UTC ticks when the application initialises.
+        /// This is incremented by the GetFiredTriggerRecordId method.
         /// </summary>
         private static long _ftrCtr = SystemTime.UtcNow().Ticks;
 
         /// <summary>
-        /// Gets the fired trigger record id.
+        /// Gets a unique fired trigger record id.
         /// </summary>
-        /// <returns>The fired trigger record id.</returns>
+        /// <returns>The unique fired trigger record id.</returns>
         protected virtual string GetFiredTriggerRecordId()
         {
             long value = Interlocked.Increment(ref _ftrCtr);

--- a/src/QuartzNET-DynamoDB/JobStore.cs
+++ b/src/QuartzNET-DynamoDB/JobStore.cs
@@ -1370,7 +1370,6 @@ namespace Quartz.DynamoDB
 
         /// <summary>
         /// Takes a collection of quartz trigger objects and sets their dynamo state.
-        /// Uses the batch 
         /// </summary>
         /// <param name="triggers">The triggers to update</param>
         /// <param name="state">The state to set.</param>
@@ -1383,20 +1382,10 @@ namespace Quartz.DynamoDB
                 var record = _triggerRepository.Load(triggers[i].Key.ToDictionary());
                 record.State = state;
                 dynamoTriggers.Add(record);
-
-                if (i + 1 == triggers.Count)
-                {
-                    // If we've reached the end of the collection, send off the save request
-                    _triggerRepository.Store(dynamoTriggers);
-                }
-                else if (i % 25 == 0)
-                {
-                    // If we've reached a factor of 25, send off the save request.
-                    _triggerRepository.Store(dynamoTriggers);
-                    // Then clear the collection and keep going.
-                    dynamoTriggers.Clear();
-                }
             }
+
+            _triggerRepository.Store(dynamoTriggers);
+
         }
 
         /// <summary> 


### PR DESCRIPTION
#7 
* Small todo, added some documentation.
* Small todo, removed question. The answer is no, it doesn't create multiple instances. There was already a test that proves this: https://github.com/lukeryannetnz/quartznet-dynamodb/blob/master/src/QuartzNET-DynamoDB.Tests/Integration/JobStore/SchedulerIntegrationTests.cs#L25
* Some resharper tidy-up, renamed static variable and fixed xml doc comment location.
* Fix two todo's in JobStore for setting state of triggers. Rather than one update call to Dynamo per item, use the BatchWriteItem dynamo API.  Add tests for new repository method. http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchWriteItem.html