### PR TITLE
Dependencies not set on nuget package

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,7 +41,7 @@ build:
   project: src\QuartzNET-DynamoDB.sln   
 
 after_build:
-- ps: nuget pack src\QuartzNET-DynamoDB\QuartzNET-DynamoDB.nuspec -IncludeReferencedProjects -version "$env:nugetVersion"
+- ps: nuget pack src\QuartzNET-DynamoDB\QuartzNET-DynamoDB.csproj -IncludeReferencedProjects -version "$env:nugetVersion"
 
 #---------------------------------#
 #       test configuration        #

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,7 +41,7 @@ build:
   project: src\QuartzNET-DynamoDB.sln   
 
 after_build:
-- ps: nuget pack $env:APPVEYOR_BUILD_FOLDER\src\QuartzNET-DynamoDB\QuartzNET-DynamoDB.csproj -IncludeReferencedProjects -version "$env:nugetVersion"
+- ps: nuget pack $env:APPVEYOR_BUILD_FOLDER\src\QuartzNET-DynamoDB\QuartzNET-DynamoDB.csproj -IncludeReferencedProjects -version "$env:nugetVersion" -BasePath $env:APPVEYOR_BUILD_FOLDER\src\QuartzNET-DynamoDB
 
 #---------------------------------#
 #       test configuration        #

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,7 +41,7 @@ build:
   project: src\QuartzNET-DynamoDB.sln   
 
 after_build:
-- ps: nuget pack src\QuartzNET-DynamoDB\QuartzNET-DynamoDB.csproj -IncludeReferencedProjects -version "$env:nugetVersion"
+- ps: nuget pack $env:APPVEYOR_BUILD_FOLDER\src\QuartzNET-DynamoDB\QuartzNET-DynamoDB.csproj -IncludeReferencedProjects -version "$env:nugetVersion"
 
 #---------------------------------#
 #       test configuration        #


### PR DESCRIPTION
#31 

<img width="771" alt="screen shot 2017-02-19 at 10 46 12 pm" src="https://cloud.githubusercontent.com/assets/372207/23101304/532fcd58-f6f5-11e6-88c3-8ea0327c5951.png">

I noticed that the dependencies weren't being set on the nuget package. 
Turns out you need to call 'nuget pack' with the .csproj as the parameter in order for it to infer dependencies from references. 

Tested with a local pack, working a treat.