### PR TITLE
Change nuspec version number format

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,11 +7,11 @@ environment:
   AWS_ACCESS_KEY_ID: AKID
   AWS_SECRET_ACCESS_KEY: SECRET
   AWS_REGION: us-east-1
-  packageVersion: 1.0.0
+  packageVersion: 1.0
 
 init:
 - ps: $env:buildVersion = "$env:packageVersion.$env:appveyor_build_number"
-- ps: $env:nugetVersion = "$env:packageVersion-$env:appveyor_build_number"
+- ps: $env:nugetVersion = "$env:packageVersion.$env:appveyor_build_number"
 
 assembly_info:
   patch: true


### PR DESCRIPTION
Despite the error clearly stating that the issue is that the label can't contain ONLY numerics:

> Error publishing package. NuGet server returned 400: Package Version invalid: the release label can not only contain numerics.

I suspect the problem is the dash. 
The [docs](https://docs.microsoft.com/en-us/nuget/schema/nuspec) state: 

> The version of the package, following the major.minor.patch pattern. Version numbers may include a pre-release suffix as described in Prerelease Packages

This PR changes the version to 1.0.BUILD