### PR TITLE
Retry when DynamoDB capacity exceeded

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ environment:
   AWS_ACCESS_KEY_ID: AKID
   AWS_SECRET_ACCESS_KEY: SECRET
   AWS_REGION: us-east-1
-  packageVersion: 1.0
+  packageVersion: 1.1
 
 init:
 - ps: $env:buildVersion = "$env:packageVersion.$env:appveyor_build_number"

--- a/src/QuartzNET-DynamoDB.Tests/QuartzNET-DynamoDB.Tests.csproj
+++ b/src/QuartzNET-DynamoDB.Tests/QuartzNET-DynamoDB.Tests.csproj
@@ -94,6 +94,7 @@
     <Compile Include="Unit\DateTimeOffsetConverterTests.cs" />
     <Compile Include="Unit\DynamoJobSerialisationTests.cs" />
     <Compile Include="Unit\DynamoTriggerTests.cs" />
+    <Compile Include="Unit\ExponentialBackoffWithRandomVariationTests.cs" />
     <Compile Include="Unit\JobDataMapConverterTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Unit\TriggerSerialisationAbstractTriggerTests.cs" />

--- a/src/QuartzNET-DynamoDB.Tests/Unit/ExponentialBackoffWithRandomVariationTests.cs
+++ b/src/QuartzNET-DynamoDB.Tests/Unit/ExponentialBackoffWithRandomVariationTests.cs
@@ -7,7 +7,7 @@ namespace Quartz.DynamoDB.Tests.Unit
     public class ExponentialBackoffWithRandomVariationTests
     {
         /// <summary>
-        /// First attempt sleep should be between 1 and 2.
+        /// First attempt sleep duration should be between 1 and 2.
         /// </summary>
         [Fact]
         public void CalculateWaitDurationFirstAttempt()
@@ -18,7 +18,7 @@ namespace Quartz.DynamoDB.Tests.Unit
         }
 
         /// <summary>
-        /// Second attempt sleep should be between 8 and 16.
+        /// Second attempt sleep duration should be between 8 and 16.
         /// </summary>
         [Fact]
         public void CalculateWaitDurationSecondAttempt()
@@ -29,7 +29,7 @@ namespace Quartz.DynamoDB.Tests.Unit
         }
 
         /// <summary>
-        /// Third attempt sleep should be between 27 and 54.
+        /// Third attempt sleep duration should be between 27 and 54.
         /// </summary>
         [Fact]
         public void CalculateWaitDurationThirdAttempt()
@@ -40,7 +40,7 @@ namespace Quartz.DynamoDB.Tests.Unit
         }
 
         /// <summary>
-        /// Fourth attempt sleep should be between 64 and 128.
+        /// Fourth attempt sleep duration should be between 64 and 128.
         /// </summary>
         [Fact]
         public void CalculateWaitDurationFourthAttempt()
@@ -51,7 +51,7 @@ namespace Quartz.DynamoDB.Tests.Unit
         }
 
         /// <summary>
-        /// Fifth attempt sleep should be between 125 and 250.
+        /// Fifth attempt sleep duration should be between 125 and 250.
         /// </summary>
         [Fact]
         public void CalculateWaitDurationFifthAttempt()

--- a/src/QuartzNET-DynamoDB.Tests/Unit/ExponentialBackoffWithRandomVariationTests.cs
+++ b/src/QuartzNET-DynamoDB.Tests/Unit/ExponentialBackoffWithRandomVariationTests.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using Quartz.DynamoDB.DataModel.Storage;
+using Xunit;
+
+namespace Quartz.DynamoDB.Tests.Unit
+{
+    public class ExponentialBackoffWithRandomVariationTests
+    {
+        /// <summary>
+        /// First attempt sleep should be between 1 and 2.
+        /// </summary>
+        [Fact]
+        public void CalculateWaitDurationFirstAttempt()
+        {
+            TimeSpan result = ExponentialBackoffWithRandomVariation.CalculateWaitDuration(1);
+            Assert.True(result >= TimeSpan.FromSeconds(1));
+            Assert.True(result <= TimeSpan.FromSeconds(2));
+        }
+
+        /// <summary>
+        /// Second attempt sleep should be between 8 and 16.
+        /// </summary>
+        [Fact]
+        public void CalculateWaitDurationSecondAttempt()
+        {
+            TimeSpan result = ExponentialBackoffWithRandomVariation.CalculateWaitDuration(2);
+            Assert.True(result >= TimeSpan.FromSeconds(8));
+            Assert.True(result <= TimeSpan.FromSeconds(16));
+        }
+
+        /// <summary>
+        /// Third attempt sleep should be between 27 and 54.
+        /// </summary>
+        [Fact]
+        public void CalculateWaitDurationThirdAttempt()
+        {
+            TimeSpan result = ExponentialBackoffWithRandomVariation.CalculateWaitDuration(3);
+            Assert.True(result >= TimeSpan.FromSeconds(27));
+            Assert.True(result <= TimeSpan.FromSeconds(54));
+        }
+
+        /// <summary>
+        /// Fourth attempt sleep should be between 64 and 128.
+        /// </summary>
+        [Fact]
+        public void CalculateWaitDurationFourthAttempt()
+        {
+            TimeSpan result = ExponentialBackoffWithRandomVariation.CalculateWaitDuration(4);
+            Assert.True(result >= TimeSpan.FromSeconds(64));
+            Assert.True(result <= TimeSpan.FromSeconds(128));
+        }
+
+        /// <summary>
+        /// Fifth attempt sleep should be between 125 and 250.
+        /// </summary>
+        [Fact]
+        public void CalculateWaitDurationFifthAttempt()
+        {
+            TimeSpan result = ExponentialBackoffWithRandomVariation.CalculateWaitDuration(5);
+            Assert.True(result >= TimeSpan.FromSeconds(125));
+            Assert.True(result <= TimeSpan.FromSeconds(250));
+        }
+    }
+}

--- a/src/QuartzNET-DynamoDB/DataModel/Storage/ExponentialBackoffWithRandomVariation.cs
+++ b/src/QuartzNET-DynamoDB/DataModel/Storage/ExponentialBackoffWithRandomVariation.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+namespace Quartz.DynamoDB.DataModel.Storage
+{
+    /// <summary>
+    /// Calculates a backoff duration that is the input cubed
+    /// plus a random value between one and the input cubed.
+    /// </summary>
+    public class ExponentialBackoffWithRandomVariation
+    {
+        private static readonly Random Random = new Random();
+
+        public static TimeSpan CalculateWaitDuration(int retryAttempt)
+        {
+            int delay = (int)Math.Pow(retryAttempt, 3);
+
+            delay += Random.Next(1, delay);
+
+            return TimeSpan.FromSeconds(delay);
+        }
+    }
+}

--- a/src/QuartzNET-DynamoDB/DataModel/Storage/Repository.cs
+++ b/src/QuartzNET-DynamoDB/DataModel/Storage/Repository.cs
@@ -129,7 +129,7 @@ namespace Quartz.DynamoDB.DataModel.Storage
             }
 
             var policy = Policy<PutItemResponse>.Handle<ProvisionedThroughputExceededException>()
-              .Retry();
+              .WaitAndRetry(5, ExponentialBackoffWithRandomVariation.CalculateWaitDuration);
 
             var response = policy.Execute(() => _client.PutItem(request));
 

--- a/src/QuartzNET-DynamoDB/DataModel/Storage/Repository.cs
+++ b/src/QuartzNET-DynamoDB/DataModel/Storage/Repository.cs
@@ -7,9 +7,9 @@ using Amazon.DynamoDBv2.Model;
 
 namespace Quartz.DynamoDB.DataModel.Storage
 {
-    public class Repository<T> : IRepository<T>, IDisposable where T : IInitialisableFromDynamoRecord, IConvertibleToDynamoRecord, IDynamoTableType, new()
+    public class Repository<T> : IRepository<T> where T : IInitialisableFromDynamoRecord, IConvertibleToDynamoRecord, IDynamoTableType, new()
     {
-        private AmazonDynamoDBClient _client;
+        private readonly AmazonDynamoDBClient _client;
 
         public Repository(AmazonDynamoDBClient client)
         {

--- a/src/QuartzNET-DynamoDB/DataModel/Storage/Repository.cs
+++ b/src/QuartzNET-DynamoDB/DataModel/Storage/Repository.cs
@@ -11,9 +11,7 @@ namespace Quartz.DynamoDB.DataModel.Storage
     public class Repository<T> : IRepository<T> where T : IInitialisableFromDynamoRecord, IConvertibleToDynamoRecord, IDynamoTableType, new()
     {
         private readonly AmazonDynamoDBClient _client;
-
         private readonly Policy _writeRetryPolicy;
-
         private readonly Policy _readRetryPolicy;
 
         public Repository(AmazonDynamoDBClient client)

--- a/src/QuartzNET-DynamoDB/QuartzNET-DynamoDB.csproj
+++ b/src/QuartzNET-DynamoDB/QuartzNET-DynamoDB.csproj
@@ -48,6 +48,10 @@
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Polly, Version=5.0.6.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Polly.5.0.6\lib\net45\Polly.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Quartz, Version=2.5.0.0, Culture=neutral, PublicKeyToken=f6b8c98a402cc8a4, processorArchitecture=MSIL">
       <HintPath>..\packages\Quartz.2.5.0\lib\net40\Quartz.dll</HintPath>
       <Private>True</Private>

--- a/src/QuartzNET-DynamoDB/QuartzNET-DynamoDB.csproj
+++ b/src/QuartzNET-DynamoDB/QuartzNET-DynamoDB.csproj
@@ -78,6 +78,7 @@
     </Compile>
     <Compile Include="DataModel\DateTimeOffsetConverter.cs" />
     <Compile Include="DataModel\DynamoScheduler.cs" />
+    <Compile Include="DataModel\Storage\ExponentialBackoffWithRandomVariation.cs" />
     <Compile Include="DataModel\UnixEpochDateTimeExtensions.cs" />
     <Compile Include="DataModel\DynamoTrigger.cs" />
     <Compile Include="DynamoBootstrapper.cs" />

--- a/src/QuartzNET-DynamoDB/QuartzNET-DynamoDB.nuspec
+++ b/src/QuartzNET-DynamoDB/QuartzNET-DynamoDB.nuspec
@@ -14,10 +14,11 @@
       This library provides a fully functioning Amazon DynamoDB JobStore for Quartz.NET using the AWS SDK Dynamo client.
     </description>
     <tags>Amazon Dynamo DynamoDB NoSQL JobStore Quartz net Quartz.net quartznet scheduler</tags>
-     <dependencies>
+    <dependencies>
       <dependency id="AWSSDK.DynamoDBv2" version="3.3.2.1" />
       <dependency id="Newtonsoft.Json" version="9.0.1" />
       <dependency id="Quartz" version="2.5.0" />
+      <dependency id="Polly" version="5.0.6" />
     </dependencies>
   </metadata>
   <files>

--- a/src/QuartzNET-DynamoDB/packages.config
+++ b/src/QuartzNET-DynamoDB/packages.config
@@ -5,5 +5,6 @@
   <package id="Common.Logging" version="3.3.1" targetFramework="net451" />
   <package id="Common.Logging.Core" version="3.3.1" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net451" />
+  <package id="Polly" version="5.0.6" targetFramework="net451" />
   <package id="Quartz" version="2.5.0" targetFramework="net451" />
 </packages>


### PR DESCRIPTION
# Overview
Adds Polly library for exponential backoff with random seed. Will hopefully alleviate situations like we saw in production today where writes fail due to capacity being exceeded and this leaving the database in a bad state.

# Detailed changes
* Added Polly, updated nuget dependencies too. I wondered if this was a good idea for a while, I considered writing my own to avoid the dependency but Polly is so good that I decided it was worth it. 
* Added class to handle calculating backoff and tested it. Went with a cube backoff, with a random additional wait between 1 and the value of the cube. What do you think? This felt about right although arguably the first backoff could be pointless.
* Added five backoff attempts for all writes.
* After thinking about it for a while, I added backoffs for reads too. JobStore methods like TriggeredJobComplete end up doing a bunch of writes, then reads, then more writes. A capacity exception in the middle could cause a mess.
* General tidyup of the Repository class to satisfy R# mainly.

# Notable exceptions:
* Integration tests, I figure polly works so why bother?

#46 