### PR TITLE
Scheduler Cleanup with DynamoDB TTL feature

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,13 +8,13 @@ It'd be appreciated if you follow the recommendations below when submitting a pa
 ) and publish nuget packages directly out of the master branch. If your change is a breaking change or minor (backwards compatible) feature, please bump the minor or major version [here](https://github.com/lukeryannetnz/quartznet-dynamodb/blob/master/appveyor.yml#L10). If your change is just a bugfix, the build engine will bump the patch version for you.  
 
 # Developer Guide
-##Building locally
+## Building locally
 
-###Compiling
-####Windows/Visual Studio
+### Compiling
+#### Windows/Visual Studio
 If you're using windows/visual studio 2015 src/QuartzNET-DynamoDB.sln is what you're after. The solution file has nuget package restore on build so you should be good to go.
 
-####OSX/Linux
+#### OSX/Linux
 If you're using linux/osx this library compiles under mono. Our build infrastructure (travis-ci) uses a debian. Check out http://www.mono-project.com/. You'll want to install mono and make sure it's in your path as a minimum.
 There are some shell scripts to help you with common tasks if you're that way inclined:
 
@@ -22,9 +22,9 @@ There are some shell scripts to help you with common tasks if you're that way in
 
 `./mono-compile.sh` Compiles the solution in release configuration using mono xbuild.
 
-###Testing
+### Testing
 The solution uses xunit tests extensively. These are broken into two groups:
-####Unit tests
+#### Unit tests
 These are small, target one class, where possible test state not behaviour and run entirely in memory. These are marked with the xunit trait Category=Unit.
-####Integration tests
+#### Integration tests
 These are more complex tests that test behavior. The initial integration tests were ported directly from the Quartz-NET RAMJobStoreTests. These require an instance of DynamoDB to test against. Amazon provide a java stand-alone version of dynamo, see [Running DynamoDB on your computer](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Tools.DynamoDBLocal.html). These are marked with the xunit trait Category=Integration.

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ Amazon DynamoDB jobstore for Quartz.NET
 
 ## Overview
 
-Quartz.NET Quartz.NET is a full-featured, open source job scheduling system that can be used from smallest apps to large scale enterprise systems.
-
 This library provides a fully functioning Amazon DynamoDB JobStore for Quartz.NET using the AWS SDK Dynamo client. Inspired by Nanoko's Quartz.NET-MongoDB project. It is an adaptation of the original "RAMJobStore".
+
+Quartz.NET Quartz.NET is a full-featured, open source job scheduling system that can be used from smallest apps to large scale enterprise systems.
 
 ## Current State
 * Jul-2016: Work in progress. Functioning! Completing functionality and polishing.

--- a/README.md
+++ b/README.md
@@ -3,17 +3,18 @@ Amazon DynamoDB jobstore for Quartz.NET
 
 [![Build status](https://ci.appveyor.com/api/projects/status/mgrgaj6ox3yhmrgg?svg=true)](https://ci.appveyor.com/project/lukeryannetnz/quartznet-dynamodb) [Builds by AppVeyor](https://ci.appveyor.com/project/lukeryannetnz/quartznet-dynamodb)
 
-##Overview
+## Overview
 
 Quartz.NET Quartz.NET is a full-featured, open source job scheduling system that can be used from smallest apps to large scale enterprise systems.
 
 This library provides a fully functioning Amazon DynamoDB JobStore for Quartz.NET using the AWS SDK Dynamo client. Inspired by Nanoko's Quartz.NET-MongoDB project. It is an adaptation of the original "RAMJobStore".
 
-##Current State
-Jul-2016: Work in progress. Functioning! Completing functionality and polishing.
-Oct-2016: @ddhi004 joins project to work towards goal of publishing as complete nuget package. :-)
-Feb-2017: Published on nuget.org as beta package.
-Feb-2017: V1.0 on nuget.org!
+## Current State
+* Jul-2016: Work in progress. Functioning! Completing functionality and polishing.
+* Oct-2016: @ddhi004 joins project to work towards goal of publishing as complete nuget package. :-)
+* Feb-2017: Published on nuget.org as beta package.
+* Feb-2017: V1.0 on nuget.org!
+* Mar-2017: Tweaks from hardening in production.
 
 ## Usage
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ environment:
   AWS_ACCESS_KEY_ID: AKID
   AWS_SECRET_ACCESS_KEY: SECRET
   AWS_REGION: us-east-1
-  packageVersion: 1.0
+  packageVersion: 1.1
 
 init:
 - ps: $env:buildVersion = "$env:packageVersion.$env:appveyor_build_number"

--- a/src/QuartzNET-DynamoDB.Tests/Integration/DynamoClientFactory.cs
+++ b/src/QuartzNET-DynamoDB.Tests/Integration/DynamoClientFactory.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Net;
 using Amazon.DynamoDBv2;
 
 namespace Quartz.DynamoDB.Tests.Integration

--- a/src/QuartzNET-DynamoDB.Tests/Integration/DynamoClientFactory.cs
+++ b/src/QuartzNET-DynamoDB.Tests/Integration/DynamoClientFactory.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Net;
 using Amazon.DynamoDBv2;
 
 namespace Quartz.DynamoDB.Tests.Integration
@@ -12,7 +13,7 @@ namespace Quartz.DynamoDB.Tests.Integration
 
         public DynamoDB.JobStore CreateTestJobStore()
         {
-            var var = new DynamoDB.JobStore();
+            var var = new DynamoDB.JobStore(new TestDynamoBootstrapper());
             var.InstanceName = _instanceName;
 
             return var;
@@ -22,7 +23,7 @@ namespace Quartz.DynamoDB.Tests.Integration
         {
             var client = DynamoDbClientFactory.Create();
             DynamoConfiguration.InstanceName = _instanceName;
-            new DynamoBootstrapper().BootStrap(client);
+            new TestDynamoBootstrapper().BootStrap(client);
 
             return client;
         }

--- a/src/QuartzNET-DynamoDB.Tests/Integration/TestDynamoBootstrapper.cs
+++ b/src/QuartzNET-DynamoDB.Tests/Integration/TestDynamoBootstrapper.cs
@@ -1,0 +1,16 @@
+﻿using Amazon.DynamoDBv2;
+
+namespace Quartz.DynamoDB.Tests.Integration
+{
+    class TestDynamoBootstrapper : DynamoBootstrapper
+    {
+        /// <summary>
+        /// The local dynamodb doesn't yet support TTL so do nothing when this call is made otherwise an
+        /// unknown operation exception is thrown by local dynamo.
+        /// </summary>
+        protected override void SetTimeToLive(IAmazonDynamoDB client, string tableName, string attributeName)
+        {
+            return;
+        }
+    }
+}

--- a/src/QuartzNET-DynamoDB.Tests/QuartzNET-DynamoDB.Tests.csproj
+++ b/src/QuartzNET-DynamoDB.Tests/QuartzNET-DynamoDB.Tests.csproj
@@ -94,6 +94,7 @@
     <Compile Include="Unit\DateTimeOffsetConverterTests.cs" />
     <Compile Include="Unit\DynamoJobSerialisationTests.cs" />
     <Compile Include="Unit\DynamoTriggerTests.cs" />
+    <Compile Include="Unit\ExponentialBackoffWithRandomVariationTests.cs" />
     <Compile Include="Unit\JobDataMapConverterTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Unit\TriggerSerialisationAbstractTriggerTests.cs" />

--- a/src/QuartzNET-DynamoDB.Tests/QuartzNET-DynamoDB.Tests.csproj
+++ b/src/QuartzNET-DynamoDB.Tests/QuartzNET-DynamoDB.Tests.csproj
@@ -46,11 +46,11 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="AWSSDK.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
-      <HintPath>..\packages\AWSSDK.Core.3.3.8.1\lib\net45\AWSSDK.Core.dll</HintPath>
+      <HintPath>..\packages\AWSSDK.Core.3.3.10.2\lib\net45\AWSSDK.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="AWSSDK.DynamoDBv2, Version=3.3.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
-      <HintPath>..\packages\AWSSDK.DynamoDBv2.3.3.2.1\lib\net45\AWSSDK.DynamoDBv2.dll</HintPath>
+      <HintPath>..\packages\AWSSDK.DynamoDBv2.3.3.4.3\lib\net45\AWSSDK.DynamoDBv2.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Quartz, Version=2.5.0.0, Culture=neutral, PublicKeyToken=f6b8c98a402cc8a4, processorArchitecture=MSIL">
@@ -145,7 +145,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <Analyzer Include="..\packages\AWSSDK.DynamoDBv2.3.3.2.1\analyzers\dotnet\cs\AWSSDK.DynamoDBv2.CodeAnalysis.dll" />
+    <Analyzer Include="..\packages\AWSSDK.DynamoDBv2.3.3.4.3\analyzers\dotnet\cs\AWSSDK.DynamoDBv2.CodeAnalysis.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/QuartzNET-DynamoDB.Tests/QuartzNET-DynamoDB.Tests.csproj
+++ b/src/QuartzNET-DynamoDB.Tests/QuartzNET-DynamoDB.Tests.csproj
@@ -91,6 +91,7 @@
     </Compile>
     <Compile Include="Integration\JobStore\JobsAndTriggersAddTests.cs" />
     <Compile Include="Integration\JobStore\TriggerResumeTests.cs" />
+    <Compile Include="Integration\TestDynamoBootstrapper.cs" />
     <Compile Include="Unit\DateTimeOffsetConverterTests.cs" />
     <Compile Include="Unit\DynamoJobSerialisationTests.cs" />
     <Compile Include="Unit\DynamoTriggerTests.cs" />

--- a/src/QuartzNET-DynamoDB.Tests/Unit/ExponentialBackoffWithRandomVariationTests.cs
+++ b/src/QuartzNET-DynamoDB.Tests/Unit/ExponentialBackoffWithRandomVariationTests.cs
@@ -7,7 +7,7 @@ namespace Quartz.DynamoDB.Tests.Unit
     public class ExponentialBackoffWithRandomVariationTests
     {
         /// <summary>
-        /// First attempt sleep should be between 1 and 2.
+        /// First attempt sleep duration should be between 1 and 2.
         /// </summary>
         [Fact]
         public void CalculateWaitDurationFirstAttempt()
@@ -18,7 +18,7 @@ namespace Quartz.DynamoDB.Tests.Unit
         }
 
         /// <summary>
-        /// Second attempt sleep should be between 8 and 16.
+        /// Second attempt sleep duration should be between 8 and 16.
         /// </summary>
         [Fact]
         public void CalculateWaitDurationSecondAttempt()
@@ -29,7 +29,7 @@ namespace Quartz.DynamoDB.Tests.Unit
         }
 
         /// <summary>
-        /// Third attempt sleep should be between 27 and 54.
+        /// Third attempt sleep duration should be between 27 and 54.
         /// </summary>
         [Fact]
         public void CalculateWaitDurationThirdAttempt()
@@ -40,7 +40,7 @@ namespace Quartz.DynamoDB.Tests.Unit
         }
 
         /// <summary>
-        /// Fourth attempt sleep should be between 64 and 128.
+        /// Fourth attempt sleep duration should be between 64 and 128.
         /// </summary>
         [Fact]
         public void CalculateWaitDurationFourthAttempt()
@@ -51,7 +51,7 @@ namespace Quartz.DynamoDB.Tests.Unit
         }
 
         /// <summary>
-        /// Fifth attempt sleep should be between 125 and 250.
+        /// Fifth attempt sleep duration should be between 125 and 250.
         /// </summary>
         [Fact]
         public void CalculateWaitDurationFifthAttempt()

--- a/src/QuartzNET-DynamoDB.Tests/Unit/ExponentialBackoffWithRandomVariationTests.cs
+++ b/src/QuartzNET-DynamoDB.Tests/Unit/ExponentialBackoffWithRandomVariationTests.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using Quartz.DynamoDB.DataModel.Storage;
+using Xunit;
+
+namespace Quartz.DynamoDB.Tests.Unit
+{
+    public class ExponentialBackoffWithRandomVariationTests
+    {
+        /// <summary>
+        /// First attempt sleep should be between 1 and 2.
+        /// </summary>
+        [Fact]
+        public void CalculateWaitDurationFirstAttempt()
+        {
+            TimeSpan result = ExponentialBackoffWithRandomVariation.CalculateWaitDuration(1);
+            Assert.True(result >= TimeSpan.FromSeconds(1));
+            Assert.True(result <= TimeSpan.FromSeconds(2));
+        }
+
+        /// <summary>
+        /// Second attempt sleep should be between 8 and 16.
+        /// </summary>
+        [Fact]
+        public void CalculateWaitDurationSecondAttempt()
+        {
+            TimeSpan result = ExponentialBackoffWithRandomVariation.CalculateWaitDuration(2);
+            Assert.True(result >= TimeSpan.FromSeconds(8));
+            Assert.True(result <= TimeSpan.FromSeconds(16));
+        }
+
+        /// <summary>
+        /// Third attempt sleep should be between 27 and 54.
+        /// </summary>
+        [Fact]
+        public void CalculateWaitDurationThirdAttempt()
+        {
+            TimeSpan result = ExponentialBackoffWithRandomVariation.CalculateWaitDuration(3);
+            Assert.True(result >= TimeSpan.FromSeconds(27));
+            Assert.True(result <= TimeSpan.FromSeconds(54));
+        }
+
+        /// <summary>
+        /// Fourth attempt sleep should be between 64 and 128.
+        /// </summary>
+        [Fact]
+        public void CalculateWaitDurationFourthAttempt()
+        {
+            TimeSpan result = ExponentialBackoffWithRandomVariation.CalculateWaitDuration(4);
+            Assert.True(result >= TimeSpan.FromSeconds(64));
+            Assert.True(result <= TimeSpan.FromSeconds(128));
+        }
+
+        /// <summary>
+        /// Fifth attempt sleep should be between 125 and 250.
+        /// </summary>
+        [Fact]
+        public void CalculateWaitDurationFifthAttempt()
+        {
+            TimeSpan result = ExponentialBackoffWithRandomVariation.CalculateWaitDuration(5);
+            Assert.True(result >= TimeSpan.FromSeconds(125));
+            Assert.True(result <= TimeSpan.FromSeconds(250));
+        }
+    }
+}

--- a/src/QuartzNET-DynamoDB.Tests/packages.config
+++ b/src/QuartzNET-DynamoDB.Tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AWSSDK.Core" version="3.3.8.1" targetFramework="net451" />
-  <package id="AWSSDK.DynamoDBv2" version="3.3.2.1" targetFramework="net451" />
+  <package id="AWSSDK.Core" version="3.3.10.2" targetFramework="net451" />
+  <package id="AWSSDK.DynamoDBv2" version="3.3.4.3" targetFramework="net451" />
   <package id="Common.Logging" version="3.3.1" targetFramework="net451" />
   <package id="Common.Logging.Core" version="3.3.1" targetFramework="net451" />
   <package id="Quartz" version="2.5.0" targetFramework="net451" />

--- a/src/QuartzNET-DynamoDB/DataModel/Storage/ExponentialBackoffWithRandomVariation.cs
+++ b/src/QuartzNET-DynamoDB/DataModel/Storage/ExponentialBackoffWithRandomVariation.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+namespace Quartz.DynamoDB.DataModel.Storage
+{
+    /// <summary>
+    /// Calculates a backoff duration that is the input cubed
+    /// plus a random value between one and the input cubed.
+    /// </summary>
+    public class ExponentialBackoffWithRandomVariation
+    {
+        private static readonly Random Random = new Random();
+
+        public static TimeSpan CalculateWaitDuration(int retryAttempt)
+        {
+            int delay = (int)Math.Pow(retryAttempt, 3);
+
+            delay += Random.Next(1, delay);
+
+            return TimeSpan.FromSeconds(delay);
+        }
+    }
+}

--- a/src/QuartzNET-DynamoDB/DataModel/Storage/Repository.cs
+++ b/src/QuartzNET-DynamoDB/DataModel/Storage/Repository.cs
@@ -129,7 +129,7 @@ namespace Quartz.DynamoDB.DataModel.Storage
             }
 
             var policy = Policy<PutItemResponse>.Handle<ProvisionedThroughputExceededException>()
-              .Retry();
+              .WaitAndRetry(5, ExponentialBackoffWithRandomVariation.CalculateWaitDuration);
 
             var response = policy.Execute(() => _client.PutItem(request));
 

--- a/src/QuartzNET-DynamoDB/DataModel/Storage/Repository.cs
+++ b/src/QuartzNET-DynamoDB/DataModel/Storage/Repository.cs
@@ -7,9 +7,9 @@ using Amazon.DynamoDBv2.Model;
 
 namespace Quartz.DynamoDB.DataModel.Storage
 {
-    public class Repository<T> : IRepository<T>, IDisposable where T : IInitialisableFromDynamoRecord, IConvertibleToDynamoRecord, IDynamoTableType, new()
+    public class Repository<T> : IRepository<T> where T : IInitialisableFromDynamoRecord, IConvertibleToDynamoRecord, IDynamoTableType, new()
     {
-        private AmazonDynamoDBClient _client;
+        private readonly AmazonDynamoDBClient _client;
 
         public Repository(AmazonDynamoDBClient client)
         {

--- a/src/QuartzNET-DynamoDB/DataModel/Storage/Repository.cs
+++ b/src/QuartzNET-DynamoDB/DataModel/Storage/Repository.cs
@@ -11,9 +11,7 @@ namespace Quartz.DynamoDB.DataModel.Storage
     public class Repository<T> : IRepository<T> where T : IInitialisableFromDynamoRecord, IConvertibleToDynamoRecord, IDynamoTableType, new()
     {
         private readonly AmazonDynamoDBClient _client;
-
         private readonly Policy _writeRetryPolicy;
-
         private readonly Policy _readRetryPolicy;
 
         public Repository(AmazonDynamoDBClient client)

--- a/src/QuartzNET-DynamoDB/DynamoBootstrapper.cs
+++ b/src/QuartzNET-DynamoDB/DynamoBootstrapper.cs
@@ -11,7 +11,15 @@ namespace Quartz.DynamoDB
     /// </summary>
     public class DynamoBootstrapper
     {
-        public void BootStrap(IAmazonDynamoDB client)
+        /// <summary>
+        /// This method sets DynamoDB in the required state. It ensures all tables exist
+        /// and creates them if they do not. It will block and wait for the tables to be 
+        /// status ACTIVE before proceeding. 
+        /// 
+        /// Override this method if you wish to customise the manner in which tables are created.
+        /// </summary>
+        /// <param name="client">The dynamodb client to use to communicate to dynamo with.</param>
+        public virtual void BootStrap(IAmazonDynamoDB client)
         {
             if (ShouldCreate(client, DynamoConfiguration.JobDetailTableName))
             {

--- a/src/QuartzNET-DynamoDB/JobStore.cs
+++ b/src/QuartzNET-DynamoDB/JobStore.cs
@@ -1006,8 +1006,6 @@ namespace Quartz.DynamoDB
 
                 // multiple instance management. Create a running scheduler for this instance.
                 CreateOrUpdateCurrentSchedulerInstance();
-
-                DeleteExpiredSchedulers();
                 ResetTriggersAssociatedWithNonActiveSchedulers();
 
                 List<IOperableTrigger> result = new List<IOperableTrigger>();
@@ -1468,28 +1466,6 @@ namespace Quartz.DynamoDB
             };
 
             _schedulerRepository.Store(scheduler);
-        }
-
-        /// <summary>
-        /// Deletes any expired scheduler records.
-        /// </summary>
-        private void DeleteExpiredSchedulers()
-        {
-            int epochNow = SystemTime.Now().UtcDateTime.ToUnixEpochTime();
-            var expressionAttributeValues = new Dictionary<string, AttributeValue> { {
-                    ":EpochNow",
-                    new AttributeValue {
-                        N = epochNow.ToString()
-                    }
-                }
-            };
-            var filterExpression = "ExpiresUtcEpoch < :EpochNow";
-            var expiredSchedulers = _schedulerRepository.Scan(expressionAttributeValues, null, filterExpression);
-
-            foreach (var dynamoScheduler in expiredSchedulers)
-            {
-                _schedulerRepository.Delete(dynamoScheduler.Key);
-            }
         }
 
         /// <summary>

--- a/src/QuartzNET-DynamoDB/JobStore.cs
+++ b/src/QuartzNET-DynamoDB/JobStore.cs
@@ -21,6 +21,7 @@ namespace Quartz.DynamoDB
     /// </summary>
     public class JobStore : IJobStore, IDisposable
     {
+        private readonly DynamoBootstrapper _bootStrapper;
         private static readonly object LockObject = new object();
         private DynamoDBContext _context;
         private IRepository<DynamoJob> _jobRepository;
@@ -40,6 +41,15 @@ namespace Quartz.DynamoDB
         private TimeSpan _misfireThreshold;
 
         private ISchedulerSignaler _signaler;
+
+        public JobStore() : this(new DynamoBootstrapper())
+        {
+        }
+
+        public JobStore(DynamoBootstrapper bootStrapper)
+        {
+            _bootStrapper = bootStrapper;
+        }
 
         public void Initialize(ITypeLoadHelper loadHelper, ISchedulerSignaler signaler)
         {
@@ -63,7 +73,7 @@ namespace Quartz.DynamoDB
 
             lock (LockObject)
             {
-                new DynamoBootstrapper().BootStrap(client);
+                _bootStrapper.BootStrap(client);
 
                 //_loadHelper = loadHelper;
                 _signaler = signaler;

--- a/src/QuartzNET-DynamoDB/QuartzNET-DynamoDB.csproj
+++ b/src/QuartzNET-DynamoDB/QuartzNET-DynamoDB.csproj
@@ -37,15 +37,15 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="AWSSDK.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
-      <HintPath>..\packages\AWSSDK.Core.3.3.8.1\lib\net45\AWSSDK.Core.dll</HintPath>
+      <HintPath>..\packages\AWSSDK.Core.3.3.10.2\lib\net45\AWSSDK.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="AWSSDK.DynamoDBv2, Version=3.3.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
-      <HintPath>..\packages\AWSSDK.DynamoDBv2.3.3.2.1\lib\net45\AWSSDK.DynamoDBv2.dll</HintPath>
+      <HintPath>..\packages\AWSSDK.DynamoDBv2.3.3.4.3\lib\net45\AWSSDK.DynamoDBv2.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Quartz, Version=2.5.0.0, Culture=neutral, PublicKeyToken=f6b8c98a402cc8a4, processorArchitecture=MSIL">
@@ -106,7 +106,7 @@
     <None Include="QuartzNET-DynamoDB.nuspec" />
   </ItemGroup>
   <ItemGroup>
-    <Analyzer Include="..\packages\AWSSDK.DynamoDBv2.3.3.2.1\analyzers\dotnet\cs\AWSSDK.DynamoDBv2.CodeAnalysis.dll" />
+    <Analyzer Include="..\packages\AWSSDK.DynamoDBv2.3.3.4.3\analyzers\dotnet\cs\AWSSDK.DynamoDBv2.CodeAnalysis.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.

--- a/src/QuartzNET-DynamoDB/QuartzNET-DynamoDB.csproj
+++ b/src/QuartzNET-DynamoDB/QuartzNET-DynamoDB.csproj
@@ -48,6 +48,10 @@
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Polly, Version=5.0.6.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Polly.5.0.6\lib\net45\Polly.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Quartz, Version=2.5.0.0, Culture=neutral, PublicKeyToken=f6b8c98a402cc8a4, processorArchitecture=MSIL">
       <HintPath>..\packages\Quartz.2.5.0\lib\net40\Quartz.dll</HintPath>
       <Private>True</Private>

--- a/src/QuartzNET-DynamoDB/QuartzNET-DynamoDB.csproj
+++ b/src/QuartzNET-DynamoDB/QuartzNET-DynamoDB.csproj
@@ -78,6 +78,7 @@
     </Compile>
     <Compile Include="DataModel\DateTimeOffsetConverter.cs" />
     <Compile Include="DataModel\DynamoScheduler.cs" />
+    <Compile Include="DataModel\Storage\ExponentialBackoffWithRandomVariation.cs" />
     <Compile Include="DataModel\UnixEpochDateTimeExtensions.cs" />
     <Compile Include="DataModel\DynamoTrigger.cs" />
     <Compile Include="DynamoBootstrapper.cs" />

--- a/src/QuartzNET-DynamoDB/QuartzNET-DynamoDB.nuspec
+++ b/src/QuartzNET-DynamoDB/QuartzNET-DynamoDB.nuspec
@@ -15,8 +15,8 @@
     </description>
     <tags>Amazon Dynamo DynamoDB NoSQL JobStore Quartz net Quartz.net quartznet scheduler</tags>
      <dependencies>
-      <dependency id="AWSSDK.DynamoDBv2" version="3.3.2.1" />
-      <dependency id="Newtonsoft.Json" version="9.0.1" />
+      <dependency id="AWSSDK.DynamoDBv2" version="3.3.4.3" />
+      <dependency id="Newtonsoft.Json" version="10.0.1" />
       <dependency id="Quartz" version="2.5.0" />
     </dependencies>
   </metadata>

--- a/src/QuartzNET-DynamoDB/QuartzNET-DynamoDB.nuspec
+++ b/src/QuartzNET-DynamoDB/QuartzNET-DynamoDB.nuspec
@@ -14,10 +14,11 @@
       This library provides a fully functioning Amazon DynamoDB JobStore for Quartz.NET using the AWS SDK Dynamo client.
     </description>
     <tags>Amazon Dynamo DynamoDB NoSQL JobStore Quartz net Quartz.net quartznet scheduler</tags>
-     <dependencies>
+    <dependencies>
       <dependency id="AWSSDK.DynamoDBv2" version="3.3.2.1" />
       <dependency id="Newtonsoft.Json" version="9.0.1" />
       <dependency id="Quartz" version="2.5.0" />
+      <dependency id="Polly" version="5.0.6" />
     </dependencies>
   </metadata>
   <files>

--- a/src/QuartzNET-DynamoDB/packages.config
+++ b/src/QuartzNET-DynamoDB/packages.config
@@ -5,5 +5,6 @@
   <package id="Common.Logging" version="3.3.1" targetFramework="net451" />
   <package id="Common.Logging.Core" version="3.3.1" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net451" />
+  <package id="Polly" version="5.0.6" targetFramework="net451" />
   <package id="Quartz" version="2.5.0" targetFramework="net451" />
 </packages>

--- a/src/QuartzNET-DynamoDB/packages.config
+++ b/src/QuartzNET-DynamoDB/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AWSSDK.Core" version="3.3.8.1" targetFramework="net451" />
-  <package id="AWSSDK.DynamoDBv2" version="3.3.2.1" targetFramework="net451" />
+  <package id="AWSSDK.Core" version="3.3.10.2" targetFramework="net451" />
+  <package id="AWSSDK.DynamoDBv2" version="3.3.4.3" targetFramework="net451" />
   <package id="Common.Logging" version="3.3.1" targetFramework="net451" />
   <package id="Common.Logging.Core" version="3.3.1" targetFramework="net451" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net451" />
+  <package id="Newtonsoft.Json" version="10.0.1" targetFramework="net451" />
   <package id="Quartz" version="2.5.0" targetFramework="net451" />
 </packages>


### PR DESCRIPTION
# Overview
Enables the TTL feature on the Scheduler table and removes an expensive scan of this table in the AcquireNextTriggers method. 
#45 

# Description of changes
* This PR includes the bump dependencies PR #49 , as the most recent dynamo client is required for TTL support.
* Update bootstrapper to set TTL for scheduler table
* Change bootstrapper to be injected, thought about creating tables etc in constructor but decided to leave in initialise method, so made bootstrapper a member.
* Overrode bootstrapper for tests, providing an implementation that does nothing for SetTTL.
* Formatting and stylistic updates to bootstrapper class.

# Notably Missing
Any tests! The local dynamodb doesn't support this feature yet, so I think we'll need to test it manually. 

# Refs
* http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/time-to-live-ttl-how-to.html
* https://aws.amazon.com/blogs/developer/time-to-live-support-in-amazon-dynamodb/

@ddhi004 