### PR TITLE
Periodic Execution of Cleanup tasks

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ environment:
   AWS_ACCESS_KEY_ID: AKID
   AWS_SECRET_ACCESS_KEY: SECRET
   AWS_REGION: us-east-1
-  packageVersion: 1.1
+  packageVersion: 1.2
 
 init:
 - ps: $env:buildVersion = "$env:packageVersion.$env:appveyor_build_number"

--- a/src/QuartzNET-DynamoDB.Tests/QuartzNET-DynamoDB.Tests.csproj
+++ b/src/QuartzNET-DynamoDB.Tests/QuartzNET-DynamoDB.Tests.csproj
@@ -98,6 +98,7 @@
     <Compile Include="Unit\ExponentialBackoffWithRandomVariationTests.cs" />
     <Compile Include="Unit\JobDataMapConverterTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Unit\PeriodicExeutionTrackerTests.cs" />
     <Compile Include="Unit\TriggerSerialisationAbstractTriggerTests.cs" />
     <Compile Include="Unit\TriggerSerialisationCronTriggerTests.cs" />
     <Compile Include="Unit\TriggerSerialisationSimpleTriggerTests.cs" />

--- a/src/QuartzNET-DynamoDB.Tests/Unit/PeriodicExeutionTrackerTests.cs
+++ b/src/QuartzNET-DynamoDB.Tests/Unit/PeriodicExeutionTrackerTests.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using Xunit;
+
+namespace Quartz.DynamoDB.Tests.Unit
+{
+    /// <summary>
+    /// Contains tests for the periodic execution tracker.
+    /// </summary>
+    public class PeriodicExeutionTrackerTests
+    {
+        /// <summary>
+        /// The first call should return true, regarless of the whether the timespan has elapsed or not.
+        /// </summary>
+        [Fact]
+        public void FirstCallReturnsTrue()
+        {
+            var sut = new PeriodicExecutionTracker(TimeSpan.FromHours(10));
+
+            var result = sut.ShouldExecute();
+
+            Assert.True(result);
+        }
+
+        /// <summary>
+        /// Before the timespan elapses, don't execute the operation.
+        /// </summary>
+        [Fact]
+        public void BeforeTimespanElapsedShouldNotExecute()
+        {
+            var utcNow = DateTime.UtcNow;
+            var frequency = TimeSpan.FromHours(24);
+            var twentyThreeHoursInFuture = utcNow.Add(frequency).Subtract(TimeSpan.FromHours(1));
+
+            var sut = new PeriodicExecutionTracker(frequency);
+            var firstCallIsAlwaysTrue = sut.ShouldExecute();
+
+            var result = sut.ShouldExecute(twentyThreeHoursInFuture);
+            Assert.False(result);
+        }
+
+        /// <summary>
+        /// At the exact time the frequency elapses, do execute the method.
+        /// </summary>
+        [Fact]
+        public void ExactlyWhenTimespanElapsedShouldExecute()
+        {
+            var utcNow = DateTime.UtcNow;
+            var frequency = TimeSpan.FromHours(24);
+
+            var sut = new PeriodicExecutionTracker(frequency);
+            var firstCallIsAlwaysTrue = sut.ShouldExecute();
+
+            var result = sut.ShouldExecute(utcNow.Add(frequency));
+            Assert.True(result);
+        }
+
+        /// <summary>
+        /// Any time after the frequency elapses, do execute the method.
+        /// </summary>
+        [Fact]
+        public void AfterTimespanElapsedShouldExecute()
+        {
+            var utcNow = DateTime.UtcNow;
+            var frequency = TimeSpan.FromHours(24);
+            var twentyFiveHoursInFuture = utcNow.Add(frequency).Add(TimeSpan.FromHours(1));
+
+            var sut = new PeriodicExecutionTracker(frequency);
+            var firstCallIsAlwaysTrue = sut.ShouldExecute();
+
+            var result = sut.ShouldExecute(twentyFiveHoursInFuture);
+            Assert.True(result);
+        }
+
+        /// <summary>
+        /// Tests that subsequent executions return true after the elapsed period.
+        /// Tests that the tracker is tracking state correctly.
+        /// </summary>
+        [Fact]
+        public void SubsequentExecutionsOnFrequency()
+        {
+            var utcNow = DateTime.UtcNow;
+            var frequency = TimeSpan.FromHours(24);
+
+            var sut = new PeriodicExecutionTracker(frequency);
+            var firstCallIsAlwaysTrue = sut.ShouldExecute();
+
+            var lastExecution = utcNow;
+
+            for (int i = 0; i <= 9; i++)
+            {
+                lastExecution = lastExecution.Add(frequency);
+
+                var result = sut.ShouldExecute(lastExecution);
+                Assert.True(result);
+            }
+        }
+
+        /// <summary>
+        /// Tests that subsequent executions return false just before the elapsed period.
+        /// Tests that the tracker is tracking state correctly.
+        /// </summary>
+        [Fact]
+        public void SubsequentExecutionsBeforeFrequency()
+        {
+            var utcNow = DateTime.UtcNow;
+            var frequency = TimeSpan.FromHours(24);
+
+            var sut = new PeriodicExecutionTracker(frequency);
+            var firstCallIsAlwaysTrue = sut.ShouldExecute();
+
+            var lastExecution = utcNow;
+
+            for (int i = 0; i <= 9; i++)
+            {
+                lastExecution = lastExecution.Add(frequency);
+
+                var justBefore = sut.ShouldExecute(lastExecution.AddMilliseconds(-1));
+                Assert.False(justBefore);
+
+                sut.ShouldExecute(lastExecution);
+            }
+        }
+    }
+}

--- a/src/QuartzNET-DynamoDB/JobStore.cs
+++ b/src/QuartzNET-DynamoDB/JobStore.cs
@@ -127,7 +127,6 @@ namespace Quartz.DynamoDB
 
         public void Shutdown()
         {
-            // todo: remove scheduler instance from db?
             Dispose();
         }
 

--- a/src/QuartzNET-DynamoDB/PeriodicExecutionTracker.cs
+++ b/src/QuartzNET-DynamoDB/PeriodicExecutionTracker.cs
@@ -1,0 +1,45 @@
+﻿using System;
+
+namespace Quartz.DynamoDB
+{
+    /// <summary>
+    /// Tracks the state of an operation that should only execute periodically.
+    /// 
+    /// Note: This class is not threadsafe, meaning two executions could happen concurrently
+    /// this is by design, we want to minimise the number of times certain operations happen
+    /// not ensure they only happen at particular times.
+    /// </summary>
+    public class PeriodicExecutionTracker
+    {
+        private readonly TimeSpan _executionFrequency;
+
+        private DateTime _lastExecutionTime = DateTime.MinValue;
+
+        public PeriodicExecutionTracker(TimeSpan executionFrequency)
+        {
+            _executionFrequency = executionFrequency;
+        }
+
+        public bool ShouldExecute()
+        {
+            return this.ShouldExecute(DateTime.UtcNow);
+        }
+
+        public bool ShouldExecute(DateTime utcNow)
+        {
+            if (_lastExecutionTime == DateTime.MinValue)
+            {
+                _lastExecutionTime = utcNow;
+                return true;
+            }
+
+            if (_lastExecutionTime.Add(_executionFrequency).CompareTo(utcNow) <= 0)
+            {
+                _lastExecutionTime = utcNow;
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/QuartzNET-DynamoDB/QuartzNET-DynamoDB.csproj
+++ b/src/QuartzNET-DynamoDB/QuartzNET-DynamoDB.csproj
@@ -102,6 +102,7 @@
     <Compile Include="DataModel\DynamoJobState.cs" />
     <Compile Include="DataModel\DynamoJobGroupState.cs" />
     <Compile Include="DataModel\DynamoTriggerGroupState.cs" />
+    <Compile Include="PeriodicExecutionTracker.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="job_scheduling_data_2_0.xsd">


### PR DESCRIPTION
# Overview
This patch adds a collection of objects that track the last time our background cleanup operations ran. 

# Detailed Description
Schedulers register themselves for 10 minutes, so I only update them every 5. This could potentially cause a problem if you had a lengthy delay set in the scheduler. Hmm. Will be fine for our current use-case.

I only remove triggers associated with dead schedulers once every 10 minutes, I figured this was more than often enough. However, if you have a critical job this wait time might be more than you can bear. 

# Future work
Add the durations and the 10 minutes hardcoded into the CreateOrUpdateCurrentSchedulerInstance as configurable values. Write some docs on configuration. I think if you just add params to the jobstore, then quartz lets you set these with its configuration system. I wonder if we should move the appsettings values we have in DynamoConfiguration into the quartz configuration system? Tradeoff to this is that it will pollute the already giant jobstore class. Would make it much easier for those that configure via code though. 

^^ created #56 for this.

# Release Branching?
This PR merges into a release branch, I was thinking this + #47 could be the next release? Branches make managing releases like this much easier. I'd prefer to work in master, but this does mean we'll publish less noise into nuget. What do you think @ddhi004?
