### PR TITLE
Loosening version dependencies on polly

### DIFF
--- a/src/QuartzNET-DynamoDB/QuartzNET-DynamoDB.nuspec
+++ b/src/QuartzNET-DynamoDB/QuartzNET-DynamoDB.nuspec
@@ -20,7 +20,7 @@
       <dependency id="AWSSDK.DynamoDBv2" version="3.3.4.3" />
       <dependency id="Newtonsoft.Json" version="[6.0, 11.0)" />
       <dependency id="Quartz" version="2.5.0" />
-      <dependency id="Polly" version="5.0.6" />
+      <dependency id="Polly" version="[4.3, 6.0)" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
In the spirit of libraries depending on the lowest possible version, lowering the requirements for versions of polly. 

We need the latest version of dynamo for the TTL feature and Quartz is unknown to me, too hard to test on an older version (they aren't great at binary back-compat).

@ddhi004 