### PR TITLE
Release/1.3

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ environment:
   AWS_ACCESS_KEY_ID: AKID
   AWS_SECRET_ACCESS_KEY: SECRET
   AWS_REGION: us-east-1
-  packageVersion: 1.2
+  packageVersion: 1.3
 
 init:
 - ps: $env:buildVersion = "$env:packageVersion.$env:appveyor_build_number"

--- a/src/QuartzNET-DynamoDB.Tests/Integration/JobStore/TriggersFiredTests.cs
+++ b/src/QuartzNET-DynamoDB.Tests/Integration/JobStore/TriggersFiredTests.cs
@@ -72,13 +72,85 @@ namespace Quartz.DynamoDB.Tests.Integration.JobStore
             string triggerGroup = Guid.NewGuid().ToString();
 
             // http://www.quartz-scheduler.org/documentation/quartz-2.x/tutorials/tutorial-lesson-06.html
-            string cronExpression = "0/5 * * * * ?";  
+            string cronExpression = "0/5 * * * * ?";
 
             DateTimeOffset d = DateTime.UtcNow;
 
             JobDetailImpl job = new JobDetailImpl(jobName, jobGroup, typeof(NoOpJob));
             IOperableTrigger trigger = new CronTriggerImpl(triggerName, triggerGroup, job.Name, job.Group, cronExpression);
 
+            trigger.ComputeFirstFireTimeUtc(null);
+
+            _sut.StoreJobAndTrigger(job, trigger);
+
+            var acquired = _sut.AcquireNextTriggers(d.AddSeconds(9), 100, TimeSpan.FromSeconds(5));
+            Assert.True(acquired.Count > 0);
+
+            var result = _sut.TriggersFired(new List<IOperableTrigger>() { trigger });
+
+            Assert.NotNull(result);
+            Assert.Equal(1, result.Count);
+            Assert.Equal(triggerName, result[0].TriggerFiredBundle.Trigger.Key.Name);
+            Assert.Equal(triggerGroup, result[0].TriggerFiredBundle.Trigger.Key.Group);
+            Assert.Equal(jobName, result[0].TriggerFiredBundle.JobDetail.Key.Name);
+            Assert.Equal(jobGroup, result[0].TriggerFiredBundle.JobDetail.Key.Group);
+        }
+
+
+        /// <summary>
+        /// Tests that a single Daily Time Interval trigger can be fired successfully and the trigger and job keys are returned correctly
+        /// when it is.
+        /// </summary>
+        [Fact]
+        [Trait("Category", "Integration")]
+        public void DailyTimeIntervalTriggerFiredSuccessfully()
+        {
+            string jobName = Guid.NewGuid().ToString();
+            string jobGroup = Guid.NewGuid().ToString();
+            string triggerName = Guid.NewGuid().ToString();
+            string triggerGroup = Guid.NewGuid().ToString();
+
+            DateTimeOffset d = DateTime.UtcNow;
+
+            JobDetailImpl job = new JobDetailImpl(jobName, jobGroup, typeof(NoOpJob));
+            DateTime nowUtc = DateTime.UtcNow;
+            IOperableTrigger trigger = new DailyTimeIntervalTriggerImpl(triggerName, triggerGroup, job.Name, job.Group, new DateTimeOffset(DateTime.UtcNow), null, Quartz.TimeOfDay.HourMinuteAndSecondOfDay(0, 0, 0), Quartz.TimeOfDay.HourAndMinuteOfDay(23, 59), IntervalUnit.Second, 1);
+
+            trigger.ComputeFirstFireTimeUtc(null);
+
+            _sut.StoreJobAndTrigger(job, trigger);
+
+            var acquired = _sut.AcquireNextTriggers(d.AddSeconds(9), 100, TimeSpan.FromSeconds(5));
+            Assert.True(acquired.Count > 0);
+
+            var result = _sut.TriggersFired(new List<IOperableTrigger>() { trigger });
+
+            Assert.NotNull(result);
+            Assert.Equal(1, result.Count);
+            Assert.Equal(triggerName, result[0].TriggerFiredBundle.Trigger.Key.Name);
+            Assert.Equal(triggerGroup, result[0].TriggerFiredBundle.Trigger.Key.Group);
+            Assert.Equal(jobName, result[0].TriggerFiredBundle.JobDetail.Key.Name);
+            Assert.Equal(jobGroup, result[0].TriggerFiredBundle.JobDetail.Key.Group);
+        }
+
+        /// <summary>
+        /// Tests that a single Calendar Interval trigger can be fired successfully and the trigger and job keys are returned correctly
+        /// when it is.
+        /// </summary>
+        [Fact]
+        [Trait("Category", "Integration")]
+        public void CalendarIntervalTriggerFiredSuccessfully()
+        {
+            string jobName = Guid.NewGuid().ToString();
+            string jobGroup = Guid.NewGuid().ToString();
+            string triggerName = Guid.NewGuid().ToString();
+            string triggerGroup = Guid.NewGuid().ToString();
+
+            DateTimeOffset d = DateTime.UtcNow;
+
+            JobDetailImpl job = new JobDetailImpl(jobName, jobGroup, typeof(NoOpJob));
+            DateTime nowUtc = DateTime.UtcNow;
+            IOperableTrigger trigger = new CalendarIntervalTriggerImpl(triggerName, triggerGroup, jobName, jobGroup, d, null, IntervalUnit.Second, 1);
             trigger.ComputeFirstFireTimeUtc(null);
 
             _sut.StoreJobAndTrigger(job, trigger);

--- a/src/QuartzNET-DynamoDB.sln
+++ b/src/QuartzNET-DynamoDB.sln
@@ -9,7 +9,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QuartzNET-DynamoDB.Tests", 
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{2122F086-E5F1-4E8F-BE5D-8D07FC34BEB2}"
 	ProjectSection(SolutionItems) = preProject
-		..\.travis.yml = ..\.travis.yml
+		..\appveyor.yml = ..\appveyor.yml
 		VersionInfo.cs = VersionInfo.cs
 	EndProjectSection
 EndProject

--- a/src/QuartzNET-DynamoDB/JobStore.cs
+++ b/src/QuartzNET-DynamoDB/JobStore.cs
@@ -1233,11 +1233,11 @@ namespace Quartz.DynamoDB
 
                     DateTimeOffset? prevFireTime = trigger.GetPreviousFireTimeUtc();
 
-                    Debug.WriteLine("Triggering Trigger! Previous Fire Time: {0}. Next Fire Time: {1}. Repeat Interval: {2}.  Calendar: {3}. Times Triggered: {4}", trigger.GetPreviousFireTimeUtc(), trigger.GetNextFireTimeUtc(), ((SimpleTriggerImpl)trigger).RepeatInterval, trigger.CalendarName, ((SimpleTriggerImpl)trigger).TimesTriggered);
+                    Debug.WriteLine("Triggering Trigger! Previous Fire Time: {0}. Next Fire Time: {1}.  Calendar: {2}.", trigger.GetPreviousFireTimeUtc(), trigger.GetNextFireTimeUtc(), trigger.CalendarName);
 
                     trigger.Triggered(cal);
                     Debug.WriteLine("Triggered Trigger! Previous Fire Time: {0}. Next Fire Time: {1}.", trigger.GetPreviousFireTimeUtc(), trigger.GetNextFireTimeUtc());
-                    storedTrigger.Trigger = (SimpleTriggerImpl)trigger;
+                    storedTrigger.Trigger = (AbstractTrigger)trigger;
                     storedTrigger.State = DynamoTriggerState.Executing;
 
                     _triggerRepository.Store(storedTrigger);


### PR DESCRIPTION
Fix for #61. 
Assumption in JobStore meant that non-simple triggers threw an invalid cast exception. 

Fix assumes that triggers are of AbstractTrigger type, which is required as not all of the fields required to serialise a trigger are available on ITrigger unfortunately. 

Added integration tests to verify behaviour for [all concrete types of Trigger](https://github.com/quartznet/quartznet/tree/master/src/Quartz/Impl/Triggers) in Quartz.NET.

cc @ddhi004 (please review)
cc @jignesh84